### PR TITLE
install wget for health check

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -23,6 +23,9 @@ RUN if [ "$TARGETPLATFORM" = "linux/arm64" ]; then GOARCH=arm64; else GOARCH=amd
 
 FROM livekit/gstreamer:1.20.4-prod
 
+# install wget for health check
+RUN apt-get update && apt-get install -y wget
+
 # clean up
 RUN apt-get clean && \
     rm -rf /var/lib/apt/lists/* 


### PR DESCRIPTION
At present curl or wget none installed in docker. That's why health checker not possible to implement. Better to have both or at least one program. 