### PR TITLE
Handle better the case where 2 publishers with the same ingress ID connect to the same ingress instance

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ The Ingress service can be run natively on any platform supported by GStreamer.
 
 ##### Prerequisites
 
-The Ingress service is built in Go. Go >= v1.17 is needed. The following [GStreamer](https://gstreamer.freedesktop.org/) libraries and headers must be installed:
+The Ingress service is built in Go. Go >= 1.18 is needed. The following [GStreamer](https://gstreamer.freedesktop.org/) libraries and headers must be installed:
 - gstreamer
 - gst-plugins-base
 - gst-plugins-good

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -272,7 +272,7 @@ func setupHandlerRPCHandlers(conf *config.Config, handler *service.Handler, bus 
 		return err
 	}
 
-	return service.RegisterIngressRpcHandlers(rpcServer, info, ep)
+	return service.RegisterIngressRpcHandlers(rpcServer, info)
 }
 
 func getConfig(c *cli.Context) (*config.Config, error) {

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/livekit/go-rtmp v0.0.0-20230317185657-6e9cfa387c7e
 	github.com/livekit/mageutil v0.0.0-20230125210925-54e8a70427c1
 	github.com/livekit/mediatransportutil v0.0.0-20230612070454-d5299b956135
-	github.com/livekit/protocol v1.5.8-0.20230620161627-ce9e603cfda8
+	github.com/livekit/protocol v1.5.8-0.20230629015034-5cff0336ab5e
 	github.com/livekit/psrpc v0.3.1
 	github.com/livekit/server-sdk-go v1.0.12-0.20230614223322-5fdaa0386d4a
 	github.com/pion/interceptor v0.1.17

--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,5 @@
 module github.com/livekit/ingress
 
-replace github.com/livekit/protocol => ../protocol
-
 go 1.18
 
 require (

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,7 @@
 module github.com/livekit/ingress
 
+replace github.com/livekit/protocol => ../protocol
+
 go 1.18
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -87,8 +87,6 @@ github.com/livekit/mageutil v0.0.0-20230125210925-54e8a70427c1 h1:jm09419p0lqTkD
 github.com/livekit/mageutil v0.0.0-20230125210925-54e8a70427c1/go.mod h1:Rs3MhFwutWhGwmY1VQsygw28z5bWcnEYmS1OG9OxjOQ=
 github.com/livekit/mediatransportutil v0.0.0-20230612070454-d5299b956135 h1:lWYbsondvqG69czxoACDwaJ/BoyD57BahCo70ZH+m4U=
 github.com/livekit/mediatransportutil v0.0.0-20230612070454-d5299b956135/go.mod h1:MRc0zSOSzXuFt0X218SgabzlaKevkvCckPgBEoHYc34=
-github.com/livekit/protocol v1.5.8-0.20230620161627-ce9e603cfda8 h1:pri2aylzPrDDTjBKQQdcYsYqwjv9J7W8CnEkrbnF0lU=
-github.com/livekit/protocol v1.5.8-0.20230620161627-ce9e603cfda8/go.mod h1:B6hJiuXT84dHsUgaKHBo+ZLPX4XhklptYA2UbANSiNg=
 github.com/livekit/psrpc v0.3.1 h1:KfylgJHvoLQcc22t/oflwMOeSnx0c14G7cWsS+9MYS4=
 github.com/livekit/psrpc v0.3.1/go.mod h1:n6JntEg+zT6Ji8InoyTpV7wusPNwGqqtxmHlkNhDN0U=
 github.com/livekit/server-sdk-go v1.0.12-0.20230614223322-5fdaa0386d4a h1:hMCE2b1txjepy0tWv4rBfu+QHPuVUyTfgDmaO70AXwU=

--- a/go.sum
+++ b/go.sum
@@ -87,6 +87,8 @@ github.com/livekit/mageutil v0.0.0-20230125210925-54e8a70427c1 h1:jm09419p0lqTkD
 github.com/livekit/mageutil v0.0.0-20230125210925-54e8a70427c1/go.mod h1:Rs3MhFwutWhGwmY1VQsygw28z5bWcnEYmS1OG9OxjOQ=
 github.com/livekit/mediatransportutil v0.0.0-20230612070454-d5299b956135 h1:lWYbsondvqG69czxoACDwaJ/BoyD57BahCo70ZH+m4U=
 github.com/livekit/mediatransportutil v0.0.0-20230612070454-d5299b956135/go.mod h1:MRc0zSOSzXuFt0X218SgabzlaKevkvCckPgBEoHYc34=
+github.com/livekit/protocol v1.5.8-0.20230620161627-ce9e603cfda8 h1:pri2aylzPrDDTjBKQQdcYsYqwjv9J7W8CnEkrbnF0lU=
+github.com/livekit/protocol v1.5.8-0.20230620161627-ce9e603cfda8/go.mod h1:B6hJiuXT84dHsUgaKHBo+ZLPX4XhklptYA2UbANSiNg=
 github.com/livekit/psrpc v0.3.1 h1:KfylgJHvoLQcc22t/oflwMOeSnx0c14G7cWsS+9MYS4=
 github.com/livekit/psrpc v0.3.1/go.mod h1:n6JntEg+zT6Ji8InoyTpV7wusPNwGqqtxmHlkNhDN0U=
 github.com/livekit/server-sdk-go v1.0.12-0.20230614223322-5fdaa0386d4a h1:hMCE2b1txjepy0tWv4rBfu+QHPuVUyTfgDmaO70AXwU=

--- a/go.sum
+++ b/go.sum
@@ -87,8 +87,8 @@ github.com/livekit/mageutil v0.0.0-20230125210925-54e8a70427c1 h1:jm09419p0lqTkD
 github.com/livekit/mageutil v0.0.0-20230125210925-54e8a70427c1/go.mod h1:Rs3MhFwutWhGwmY1VQsygw28z5bWcnEYmS1OG9OxjOQ=
 github.com/livekit/mediatransportutil v0.0.0-20230612070454-d5299b956135 h1:lWYbsondvqG69czxoACDwaJ/BoyD57BahCo70ZH+m4U=
 github.com/livekit/mediatransportutil v0.0.0-20230612070454-d5299b956135/go.mod h1:MRc0zSOSzXuFt0X218SgabzlaKevkvCckPgBEoHYc34=
-github.com/livekit/protocol v1.5.8-0.20230620161627-ce9e603cfda8 h1:pri2aylzPrDDTjBKQQdcYsYqwjv9J7W8CnEkrbnF0lU=
-github.com/livekit/protocol v1.5.8-0.20230620161627-ce9e603cfda8/go.mod h1:B6hJiuXT84dHsUgaKHBo+ZLPX4XhklptYA2UbANSiNg=
+github.com/livekit/protocol v1.5.8-0.20230629015034-5cff0336ab5e h1:DtTFuErvQGEydKgdgv8f39wlvdUpuob33EznKoKA8f4=
+github.com/livekit/protocol v1.5.8-0.20230629015034-5cff0336ab5e/go.mod h1:B6hJiuXT84dHsUgaKHBo+ZLPX4XhklptYA2UbANSiNg=
 github.com/livekit/psrpc v0.3.1 h1:KfylgJHvoLQcc22t/oflwMOeSnx0c14G7cWsS+9MYS4=
 github.com/livekit/psrpc v0.3.1/go.mod h1:n6JntEg+zT6Ji8InoyTpV7wusPNwGqqtxmHlkNhDN0U=
 github.com/livekit/server-sdk-go v1.0.12-0.20230614223322-5fdaa0386d4a h1:hMCE2b1txjepy0tWv4rBfu+QHPuVUyTfgDmaO70AXwU=

--- a/pkg/errors/errors.go
+++ b/pkg/errors/errors.go
@@ -2,6 +2,7 @@ package errors
 
 import (
 	"errors"
+	"fmt"
 	"io"
 
 	"github.com/tinyzimmer/go-gst/gst"
@@ -54,10 +55,11 @@ func ErrHttpRelayFailure(statusCode int) psrpc.Error {
 }
 
 func ErrorToGstFlowReturn(err error) gst.FlowReturn {
-	switch errors.Unwrap(err) {
-	case nil:
+	switch {
+	case err == nil:
 		return gst.FlowOK
-	case io.EOF:
+	case errors.Is(err, io.EOF):
+		fmt.Println("ErrorToGstFlowReturn EOS")
 		return gst.FlowEOS
 	default:
 		return gst.FlowError

--- a/pkg/errors/errors.go
+++ b/pkg/errors/errors.go
@@ -2,7 +2,6 @@ package errors
 
 import (
 	"errors"
-	"fmt"
 	"io"
 
 	"github.com/tinyzimmer/go-gst/gst"
@@ -59,7 +58,6 @@ func ErrorToGstFlowReturn(err error) gst.FlowReturn {
 	case err == nil:
 		return gst.FlowOK
 	case errors.Is(err, io.EOF):
-		fmt.Println("ErrorToGstFlowReturn EOS")
 		return gst.FlowEOS
 	default:
 		return gst.FlowError

--- a/pkg/errors/errors.go
+++ b/pkg/errors/errors.go
@@ -20,6 +20,7 @@ var (
 	ErrUnsupportedEncodeFormat = psrpc.NewErrorf(psrpc.InvalidArgument, "unsupported mime type for encoder")
 	ErrDuplicateTrack          = psrpc.NewErrorf(psrpc.NotAcceptable, "more than 1 track with given media kind")
 	ErrUnableToAddPad          = psrpc.NewErrorf(psrpc.Internal, "could not add pads to bin")
+	ErrMissingResourceId       = psrpc.NewErrorf(psrpc.InvalidArgument, "missing resource ID")
 	ErrIngressNotFound         = psrpc.NewErrorf(psrpc.NotFound, "ingress not found")
 	ErrServerCapacityExceeded  = psrpc.NewErrorf(psrpc.ResourceExhausted, "server capacity exceeded")
 	ErrServerShuttingDown      = psrpc.NewErrorf(psrpc.Unavailable, "server shutting down")

--- a/pkg/media/pipeline.go
+++ b/pkg/media/pipeline.go
@@ -146,6 +146,8 @@ func (p *Pipeline) Run(ctx context.Context) {
 	// run main loop
 	p.loop.Run()
 
+	logger.Infow("GST pipeline stopped")
+
 	err = p.input.Close()
 	p.sink.Close()
 

--- a/pkg/media/whip/whipsrc.go
+++ b/pkg/media/whip/whipsrc.go
@@ -30,7 +30,7 @@ func NewWHIPRelaySource(ctx context.Context, p *params.Params) (*WHIPSource, err
 	s := &WHIPSource{
 		params:     p,
 		trackSrc:   make(map[types.StreamKind]*whipAppSource),
-		resourceId: p.ExtraParams.(*params.WhipExtraParams).ResourceId,
+		resourceId: p.State.ResourceId,
 	}
 
 	mimeTypes := s.params.ExtraParams.(*params.WhipExtraParams).MimeTypes

--- a/pkg/params/params.go
+++ b/pkg/params/params.go
@@ -69,11 +69,14 @@ func GetParams(ctx context.Context, psrpcClient rpc.IOInfoClient, conf *config.C
 	infoCopy := proto.Clone(info).(*livekit.IngressInfo)
 
 	// The state should have been created by the service, before launching the hander, but be defensive here.
-	if infoCopy.State == nil {
-		infoCopy.State = &livekit.IngressState{
-			Status:    livekit.IngressState_ENDPOINT_BUFFERING,
-			StartedAt: time.Now().UnixNano(),
-		}
+	if infoCopy.State == nil || infoCopy.State.ResourceId == "" {
+		return nil, errors.ErrMissingResourceId
+
+	}
+
+	infoCopy.State.Status = livekit.IngressState_ENDPOINT_BUFFERING
+	if infoCopy.State.StartedAt == 0 {
+		infoCopy.State.StartedAt = time.Now().UnixNano()
 	}
 
 	if infoCopy.Audio == nil {

--- a/pkg/params/params.go
+++ b/pkg/params/params.go
@@ -39,21 +39,26 @@ type Params struct {
 }
 
 type WhipExtraParams struct {
-	ResourceId string                      `json:"resource_id"`
-	MimeTypes  map[types.StreamKind]string `json:"mime_types"`
+	MimeTypes map[types.StreamKind]string `json:"mime_types"`
 }
 
 func GetParams(ctx context.Context, psrpcClient rpc.IOInfoClient, conf *config.Config, info *livekit.IngressInfo, wsUrl, token string, ep any) (*Params, error) {
 	var err error
 
+	// The state should have been created by the service, before launching the hander, but be defensive here.
+	if info.State == nil || info.State.ResourceId == "" {
+		return nil, errors.ErrMissingResourceId
+	}
+
 	relayUrl := ""
 	fields := []interface{}{"ingressID", info.IngressId}
 	switch info.InputType {
 	case livekit.IngressInput_RTMP_INPUT:
-		relayUrl = getRTMPRelayUrl(conf, info.StreamKey)
+		fields = append(fields, "resourceID", info.State.ResourceId)
+		relayUrl = getRTMPRelayUrl(conf, info.State.ResourceId)
 	case livekit.IngressInput_WHIP_INPUT:
-		fields = append(fields, "resourceID", ep.(*WhipExtraParams).ResourceId)
-		relayUrl = getWHIPRelayUrlPrefix(conf, ep.(*WhipExtraParams).ResourceId)
+		fields = append(fields, "resourceID", info.State.ResourceId)
+		relayUrl = getWHIPRelayUrlPrefix(conf, info.State.ResourceId)
 	}
 
 	err = conf.InitLogger(fields...)
@@ -71,7 +76,6 @@ func GetParams(ctx context.Context, psrpcClient rpc.IOInfoClient, conf *config.C
 	// The state should have been created by the service, before launching the hander, but be defensive here.
 	if infoCopy.State == nil || infoCopy.State.ResourceId == "" {
 		return nil, errors.ErrMissingResourceId
-
 	}
 
 	infoCopy.State.Status = livekit.IngressState_ENDPOINT_BUFFERING
@@ -119,8 +123,8 @@ func GetParams(ctx context.Context, psrpcClient rpc.IOInfoClient, conf *config.C
 	return p, nil
 }
 
-func getRTMPRelayUrl(conf *config.Config, streamKey string) string {
-	return fmt.Sprintf("http://localhost:%d/rtmp/%s", conf.HTTPRelayPort, streamKey)
+func getRTMPRelayUrl(conf *config.Config, resourceId string) string {
+	return fmt.Sprintf("http://localhost:%d/rtmp/%s", conf.HTTPRelayPort, resourceId)
 }
 
 func getWHIPRelayUrlPrefix(conf *config.Config, resourceId string) string {

--- a/pkg/params/params.go
+++ b/pkg/params/params.go
@@ -73,11 +73,6 @@ func GetParams(ctx context.Context, psrpcClient rpc.IOInfoClient, conf *config.C
 
 	infoCopy := proto.Clone(info).(*livekit.IngressInfo)
 
-	// The state should have been created by the service, before launching the hander, but be defensive here.
-	if infoCopy.State == nil || infoCopy.State.ResourceId == "" {
-		return nil, errors.ErrMissingResourceId
-	}
-
 	infoCopy.State.Status = livekit.IngressState_ENDPOINT_BUFFERING
 	if infoCopy.State.StartedAt == 0 {
 		infoCopy.State.StartedAt = time.Now().UnixNano()

--- a/pkg/rtmp/relay_handler.go
+++ b/pkg/rtmp/relay_handler.go
@@ -35,9 +35,9 @@ func (h *RTMPRelayHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		}
 	}()
 
-	streamKey := strings.TrimLeft(r.URL.Path, "/rtmp/")
+	resourceId := strings.TrimLeft(r.URL.Path, "/rtmp/")
 
-	log := logger.Logger(logger.GetLogger().WithValues("streamKey", streamKey))
+	log := logger.Logger(logger.GetLogger().WithValues("resourceID", resourceId))
 	log.Infow("relaying ingress")
 
 	pr, pw := io.Pipe()
@@ -49,13 +49,13 @@ func (h *RTMPRelayHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		close(done)
 	}()
 
-	err = h.rtmpServer.AssociateRelay(streamKey, pw)
+	err = h.rtmpServer.AssociateRelay(resourceId, pw)
 	if err != nil {
 		return
 	}
 	defer func() {
 		pw.Close()
-		h.rtmpServer.DissociateRelay(streamKey)
+		h.rtmpServer.DissociateRelay(resourceId)
 	}()
 
 	err = <-done

--- a/pkg/rtmp/server.go
+++ b/pkg/rtmp/server.go
@@ -21,10 +21,6 @@ import (
 	protoutils "github.com/livekit/protocol/utils"
 )
 
-const (
-	rtmpResourcePrefix = "RT_" // Move to protocol if this ever gets serialized into a message
-)
-
 type RTMPServer struct {
 	server   *rtmp.Server
 	handlers sync.Map
@@ -174,7 +170,7 @@ func (h *RTMPHandler) OnPublish(_ *rtmp.StreamContext, timestamp uint32, cmd *rt
 	}
 
 	_, streamKey := path.Split(cmd.PublishingName)
-	h.resourceId = protoutils.NewGuid(rtmpResourcePrefix)
+	h.resourceId = protoutils.NewGuid(protoutils.RTMPResourcePrefix)
 	h.log = logger.GetLogger().WithValues("streamKey", streamKey, "resourceID", h.resourceId)
 	if h.onPublish != nil {
 		err := h.onPublish(streamKey, h.resourceId)

--- a/pkg/rtmp/server.go
+++ b/pkg/rtmp/server.go
@@ -18,6 +18,11 @@ import (
 	"github.com/livekit/ingress/pkg/errors"
 	"github.com/livekit/ingress/pkg/utils"
 	"github.com/livekit/protocol/logger"
+	protoutils "github.com/livekit/protocol/utils"
+)
+
+const (
+	rtmpResourcePrefix = "RT_" // Move to protocol if this ever gets serialized into a message
 )
 
 type RTMPServer struct {
@@ -29,7 +34,7 @@ func NewRTMPServer() *RTMPServer {
 	return &RTMPServer{}
 }
 
-func (s *RTMPServer) Start(conf *config.Config, onPublish func(streamKey string) error) error {
+func (s *RTMPServer) Start(conf *config.Config, onPublish func(streamKey, resourceId string) error) error {
 	port := conf.RTMPPort
 
 	tcpAddr, err := net.ResolveTCPAddr("tcp", fmt.Sprintf(":%d", port))
@@ -53,20 +58,20 @@ func (s *RTMPServer) Start(conf *config.Config, onPublish func(streamKey string)
 			lf := l.WithFields(conf.GetLoggerFields())
 
 			h := NewRTMPHandler()
-			h.OnPublishCallback(func(streamKey string) error {
+			h.OnPublishCallback(func(streamKey, resourceId string) error {
 				if onPublish != nil {
-					err := onPublish(streamKey)
+					err := onPublish(streamKey, resourceId)
 					if err != nil {
 						return err
 					}
 				}
 
-				s.handlers.Store(streamKey, h)
+				s.handlers.Store(resourceId, h)
 
 				return nil
 			})
-			h.OnCloseCallback(func(streamKey string) {
-				s.handlers.Delete(streamKey)
+			h.OnCloseCallback(func(resourceId string) {
+				s.handlers.Delete(resourceId)
 			})
 
 			return conn, &rtmp.ConnConfig{
@@ -91,8 +96,8 @@ func (s *RTMPServer) Start(conf *config.Config, onPublish func(streamKey string)
 	return nil
 }
 
-func (s *RTMPServer) AssociateRelay(streamKey string, w io.WriteCloser) error {
-	h, ok := s.handlers.Load(streamKey)
+func (s *RTMPServer) AssociateRelay(resourceId string, w io.WriteCloser) error {
+	h, ok := s.handlers.Load(resourceId)
 	if ok && h != nil {
 		err := h.(*RTMPHandler).SetWriter(w)
 		if err != nil {
@@ -105,8 +110,8 @@ func (s *RTMPServer) AssociateRelay(streamKey string, w io.WriteCloser) error {
 	return nil
 }
 
-func (s *RTMPServer) DissociateRelay(streamKey string) error {
-	h, ok := s.handlers.Load(streamKey)
+func (s *RTMPServer) DissociateRelay(resourceId string) error {
+	h, ok := s.handlers.Load(resourceId)
 	if ok && h != nil {
 		err := h.(*RTMPHandler).SetWriter(nil)
 		if err != nil {
@@ -127,7 +132,7 @@ type RTMPHandler struct {
 	rtmp.DefaultHandler
 
 	flvEnc        *flv.Encoder
-	streamKey     string
+	resourceId    string
 	videoInit     *flvtag.VideoData
 	audioInit     *flvtag.AudioData
 	keyFrameFound bool
@@ -135,8 +140,8 @@ type RTMPHandler struct {
 
 	log logger.Logger
 
-	onPublish func(streamKey string) error
-	onClose   func(streamKey string)
+	onPublish func(streamKey, resourceId string) error
+	onClose   func(resourceId string)
 }
 
 func NewRTMPHandler() *RTMPHandler {
@@ -154,11 +159,11 @@ func NewRTMPHandler() *RTMPHandler {
 	return h
 }
 
-func (h *RTMPHandler) OnPublishCallback(cb func(streamKey string) error) {
+func (h *RTMPHandler) OnPublishCallback(cb func(streamKey, resourceId string) error) {
 	h.onPublish = cb
 }
 
-func (h *RTMPHandler) OnCloseCallback(cb func(streamKey string)) {
+func (h *RTMPHandler) OnCloseCallback(cb func(resourceId string)) {
 	h.onClose = cb
 }
 
@@ -168,12 +173,11 @@ func (h *RTMPHandler) OnPublish(_ *rtmp.StreamContext, timestamp uint32, cmd *rt
 		return errors.ErrMissingStreamKey
 	}
 
-	// TODO check in store that PublishingName == stream key belongs to a valid ingress
-
-	_, h.streamKey = path.Split(cmd.PublishingName)
-	h.log = logger.GetLogger().WithValues("streamKey", h.streamKey)
+	_, streamKey := path.Split(cmd.PublishingName)
+	h.resourceId = protoutils.NewGuid(rtmpResourcePrefix)
+	h.log = logger.GetLogger().WithValues("streamKey", streamKey, "resourceID", h.resourceId)
 	if h.onPublish != nil {
-		err := h.onPublish(h.streamKey)
+		err := h.onPublish(streamKey, h.resourceId)
 		if err != nil {
 			return err
 		}
@@ -297,7 +301,7 @@ func (h *RTMPHandler) OnClose() {
 	h.mediaBuffer.Close()
 
 	if h.onClose != nil {
-		h.onClose(h.streamKey)
+		h.onClose(h.resourceId)
 	}
 }
 

--- a/pkg/rtmp/server.go
+++ b/pkg/rtmp/server.go
@@ -204,7 +204,8 @@ func (h *RTMPHandler) OnSetDataFrame(timestamp uint32, data *rtmpmsg.NetStreamSe
 		Timestamp: timestamp,
 		Data:      &script,
 	}); err != nil {
-		h.log.Errorw("failed to forward script data", err)
+		h.log.Warnw("failed to forward script data", err)
+		return err
 	}
 
 	return nil
@@ -239,8 +240,8 @@ func (h *RTMPHandler) OnAudio(timestamp uint32, payload io.Reader) error {
 		Timestamp: timestamp,
 		Data:      &audio,
 	}); err != nil {
-		// log and continue, or fail and let sender reconnect?
-		h.log.Errorw("failed to write audio", err)
+		h.log.Warnw("failed to write audio", err)
+		return err
 	}
 
 	return nil
@@ -283,7 +284,8 @@ func (h *RTMPHandler) OnVideo(timestamp uint32, payload io.Reader) error {
 		Timestamp: timestamp,
 		Data:      &video,
 	}); err != nil {
-		h.log.Errorw("Failed to write video", err)
+		h.log.Warnw("Failed to write video", err)
+		return err
 	}
 
 	return nil

--- a/pkg/service/process_manager.go
+++ b/pkg/service/process_manager.go
@@ -99,7 +99,7 @@ func (s *ProcessManager) launchHandler(ctx context.Context, resp *rpc.GetIngress
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 
-	s.sm.IngressStarted(resp.Info, SessionType_HandlerProcess)
+	s.sm.IngressStarted(resp.Info)
 	h := &process{
 		info:   resp.Info,
 		cmd:    cmd,
@@ -107,7 +107,7 @@ func (s *ProcessManager) launchHandler(ctx context.Context, resp *rpc.GetIngress
 	}
 
 	s.mu.Lock()
-	s.activeHandlers[resp.Info.IngressId] = h
+	s.activeHandlers[resp.Info.State.ResourceId] = h
 	s.mu.Unlock()
 
 	go s.awaitCleanup(h)
@@ -127,7 +127,7 @@ func (s *ProcessManager) awaitCleanup(h *process) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	delete(s.activeHandlers, h.info.IngressId)
+	delete(s.activeHandlers, h.info.State.ResourceId)
 }
 
 func (s *ProcessManager) killAll() {

--- a/pkg/service/service.go
+++ b/pkg/service/service.go
@@ -86,7 +86,7 @@ func NewService(conf *config.Config, psrpcClient rpc.IOInfoClient, bus psrpc.Mes
 	return s
 }
 
-func (s *Service) HandleRTMPPublishRequest(streamKey string) error {
+func (s *Service) HandleRTMPPublishRequest(streamKey, resourceId string) error {
 	ctx, span := tracer.Start(context.Background(), "Service.HandleRTMPPublishRequest")
 	defer span.End()
 
@@ -210,7 +210,7 @@ func (s *Service) HandleWHIPPublishRequest(streamKey, resourceId string, ihs rpc
 	return p, ready, ended, nil
 }
 
-func (s *Service) handleNewPublisher(ctx context.Context, streamKey string, inputType livekit.IngressInput) (*rpc.GetIngressInfoResponse, error) {
+func (s *Service) handleNewPublisher(ctx context.Context, streamKey string, resourceId string, inputType livekit.IngressInput) (*rpc.GetIngressInfoResponse, error) {
 	resp, err := s.psrpcClient.GetIngressInfo(ctx, &rpc.GetIngressInfoRequest{
 		StreamKey: streamKey,
 	})
@@ -234,8 +234,9 @@ func (s *Service) handleNewPublisher(ctx context.Context, streamKey string, inpu
 	}
 
 	resp.Info.State = &livekit.IngressState{
-		Status:    livekit.IngressState_ENDPOINT_BUFFERING,
-		StartedAt: time.Now().UnixNano(),
+		Status:     livekit.IngressState_ENDPOINT_BUFFERING,
+		StartedAt:  time.Now().UnixNano(),
+		ResourceId: resourceId,
 	}
 
 	return resp, nil

--- a/pkg/whip/whip_handler.go
+++ b/pkg/whip/whip_handler.go
@@ -63,7 +63,7 @@ func NewWHIPHandler(webRTCConfig *rtcconfig.WebRTCConfig) *whipHandler {
 func (h *whipHandler) Init(ctx context.Context, p *params.Params, sdpOffer string) (string, error) {
 	var err error
 
-	h.logger = logger.GetLogger().WithValues("ingressID", p.IngressId, "resourceID", p.ExtraParams.(*params.WhipExtraParams).ResourceId)
+	h.logger = logger.GetLogger().WithValues("ingressID", p.IngressId, "resourceID", p.State.ResourceId)
 	h.params = p
 
 	if p.BypassTranscoding {


### PR DESCRIPTION
This generates a resourceID for rtmp sessions as well, and uses it to differentiate the different sessions, even if they belong to the same ingress.

This also make sure the ingress session terminates properly if the participant gets removed from the room (because another one if the same participant id joined, for instance).

This should prevent 2 ingress with the same ID to be started at the same time, even if they end up being handled by a different ingress server, as the room logic will terminate the older one of the 2 sessions. There is already explicit logic to terminate any active ingress session if the ingress gets modified to change the participant_id.