### PR TITLE
Split the whip writer in a separate goroutine

### DIFF
--- a/pkg/service/service.go
+++ b/pkg/service/service.go
@@ -333,9 +333,10 @@ func (s *Service) Run() error {
 
 func (s *Service) sendUpdate(ctx context.Context, info *livekit.IngressInfo, err error) {
 	var state *livekit.IngressState
-	if info != nil {
-		state = info.State
+	if info == nil {
+		return
 	}
+	state = info.State
 	if state == nil {
 		state = &livekit.IngressState{}
 	}

--- a/pkg/whip/whip_track_handler.go
+++ b/pkg/whip/whip_track_handler.go
@@ -82,7 +82,7 @@ func newWHIPTrackHandler(
 		writePLI:        writePLI,
 		onRTCP:          onRTCP,
 		fuse:            core.NewFuse(),
-		mediaPushedChan: make(chan struct{}),
+		mediaPushedChan: make(chan struct{}, 1),
 	}
 
 	jb, err := t.createJitterBuffer()
@@ -139,6 +139,7 @@ func (t *whipTrackHandler) startRTPReceiver(onDone func(err error)) {
 			default:
 				err = t.processRTPPacket()
 				switch err {
+				case nil:
 				case io.EOF:
 					err = nil
 					return

--- a/pkg/whip/whip_track_handler.go
+++ b/pkg/whip/whip_track_handler.go
@@ -59,8 +59,9 @@ type whipTrackHandler struct {
 	statsLock sync.Mutex
 	stats     *stats.MediaStatsReporter
 
-	firstPacket sync.Once
-	fuse        core.Fuse
+	firstPacket     sync.Once
+	fuse            core.Fuse
+	mediaPushedChan chan struct{}
 }
 
 func newWHIPTrackHandler(
@@ -73,14 +74,15 @@ func newWHIPTrackHandler(
 	onRTCP func(packet rtcp.Packet),
 ) (*whipTrackHandler, error) {
 	t := &whipTrackHandler{
-		logger:      logger,
-		remoteTrack: track,
-		receiver:    receiver,
-		sync:        sync,
-		mediaSink:   mediaSink,
-		writePLI:    writePLI,
-		onRTCP:      onRTCP,
-		fuse:        core.NewFuse(),
+		logger:          logger,
+		remoteTrack:     track,
+		receiver:        receiver,
+		sync:            sync,
+		mediaSink:       mediaSink,
+		writePLI:        writePLI,
+		onRTCP:          onRTCP,
+		fuse:            core.NewFuse(),
+		mediaPushedChan: make(chan struct{}),
 	}
 
 	jb, err := t.createJitterBuffer()
@@ -122,13 +124,6 @@ func (t *whipTrackHandler) startRTPReceiver(onDone func(err error)) {
 	go func() {
 		var err error
 
-		defer func() {
-			t.mediaSink.Close()
-			if onDone != nil {
-				onDone(err)
-			}
-		}()
-
 		t.logger.Infow("starting rtp receiver")
 
 		if t.remoteTrack.Kind() == webrtc.RTPCodecTypeVideo && t.writePLI != nil {
@@ -144,8 +139,6 @@ func (t *whipTrackHandler) startRTPReceiver(onDone func(err error)) {
 			default:
 				err = t.processRTPPacket()
 				switch err {
-				case nil, errors.ErrPrerollBufferReset:
-					// continue
 				case io.EOF:
 					err = nil
 					return
@@ -160,6 +153,11 @@ func (t *whipTrackHandler) startRTPReceiver(onDone func(err error)) {
 			}
 		}
 	}()
+
+	go func() {
+		t.mediaWriterWorker(onDone)
+	}()
+
 }
 
 // TODO drain on close?
@@ -180,6 +178,52 @@ func (t *whipTrackHandler) processRTPPacket() error {
 
 	t.jb.Push(pkt)
 
+	// wake up the consumer
+	select {
+	case t.mediaPushedChan <- struct{}{}:
+	default:
+	}
+
+	return nil
+}
+
+func (t *whipTrackHandler) mediaWriterWorker(onDone func(err error)) {
+	var err error
+
+	defer func() {
+		t.mediaSink.Close()
+		if onDone != nil {
+			onDone(err)
+		}
+	}()
+
+	for {
+		select {
+		case <-t.mediaPushedChan:
+			err := t.forwardAvailableMedia()
+			switch err {
+			case nil, errors.ErrPrerollBufferReset:
+				// continue
+			case io.EOF:
+				err = nil
+				return
+			default:
+				if netErr, ok := err.(net.Error); ok && netErr.Timeout() {
+					continue
+				}
+
+				t.logger.Warnw("error writing media", err)
+				return
+			}
+		case <-t.fuse.Watch():
+			t.logger.Debugw("stopping media forwarder")
+			err = nil
+			return
+		}
+	}
+}
+
+func (t *whipTrackHandler) forwardAvailableMedia() error {
 	for {
 		pkts := t.jb.Pop(false)
 		if len(pkts) == 0 {
@@ -187,6 +231,7 @@ func (t *whipTrackHandler) processRTPPacket() error {
 		}
 
 		var ts time.Duration
+		var err error
 		var buffer bytes.Buffer // TODO reuse the same buffer across calls, after resetting it if buffer allocation is a performane bottleneck
 		for _, pkt := range pkts {
 			ts, err = t.sync.GetPTS(pkt)


### PR DESCRIPTION
This should limit jitter on the reader routine since the writer blocks on the local participant reader, which operates off a ticker.