### PR TITLE
Add video/mpegts to the list of supported url pull media types

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/livekit/ingress
 
-go 1.18
+go 1.20
 
 replace github.com/tinyzimmer/go-glib => github.com/livekit/go-glib v0.0.0-20230811224737-7bfaa4e57420
 

--- a/pkg/errors/errors.go
+++ b/pkg/errors/errors.go
@@ -30,7 +30,7 @@ var (
 	ErrInvalidAudioPreset      = psrpc.NewErrorf(psrpc.InvalidArgument, "invalid audio encoding preset")
 	ErrInvalidVideoPreset      = psrpc.NewErrorf(psrpc.InvalidArgument, "invalid video encoding preset")
 	ErrSourceNotReady          = psrpc.NewErrorf(psrpc.FailedPrecondition, "source encoder not ready")
-	ErrUnsupportedDecodeFormat = psrpc.NewErrorf(psrpc.NotAcceptable, "unsupported mime type for the source media")
+	ErrUnsupportedDecodeFormat = psrpc.NewErrorf(psrpc.NotAcceptable, "unsupported format for the source media")
 	ErrUnsupportedEncodeFormat = psrpc.NewErrorf(psrpc.InvalidArgument, "unsupported mime type for encoder")
 	ErrDuplicateTrack          = psrpc.NewErrorf(psrpc.NotAcceptable, "more than 1 track with given media kind")
 	ErrUnableToAddPad          = psrpc.NewErrorf(psrpc.Internal, "could not add pads to bin")
@@ -66,6 +66,10 @@ func ErrHttpRelayFailure(statusCode int) psrpc.Error {
 	// Any failure in the relay between the handler and the service is treated as internal
 
 	return psrpc.NewErrorf(psrpc.Internal, "HTTP request failed with code %d", statusCode)
+}
+
+func ErrUnsupportedDecodeMimeType(mimeType string) psrpc.Error {
+	return psrpc.NewErrorf(psrpc.NotAcceptable, "unsupported mime type (%s) for the source media", mimeType)
 }
 
 func ErrorToGstFlowReturn(err error) gst.FlowReturn {

--- a/pkg/media/urlpull/source.go
+++ b/pkg/media/urlpull/source.go
@@ -114,7 +114,7 @@ func (s *URLSource) ValidateCaps(caps *gst.Caps) error {
 		}
 	}
 
-	return errors.ErrUnsupportedDecodeFormat
+	return errors.ErrUnsupportedDecodeMimeType(str.Name())
 }
 
 func (u *URLSource) Start(ctx context.Context) error {

--- a/pkg/media/urlpull/source.go
+++ b/pkg/media/urlpull/source.go
@@ -30,6 +30,7 @@ var (
 		"video/quicktime",
 		"video/x-matroska",
 		"video/webm",
+		"video/mpegts",
 		"audio/ogg",
 		"application/x-id3",
 		"audio/mpeg",

--- a/pkg/media/whip/appsrc.go
+++ b/pkg/media/whip/appsrc.go
@@ -165,5 +165,5 @@ func getCapsForCodec(mimeType string) (*gst.Caps, error) {
 		return gst.NewCapsFromString("audio/x-opus,channel-mapping-family=0"), nil
 	}
 
-	return nil, errors.ErrUnsupportedDecodeFormat
+	return nil, errors.ErrUnsupportedDecodeMimeType(mimeType)
 }

--- a/pkg/whip/sdk_media_sink.go
+++ b/pkg/whip/sdk_media_sink.go
@@ -187,7 +187,7 @@ func getVideoParams(mimeType string, s *media.Sample) (uint, uint, error) {
 	case strings.ToLower(webrtc.MimeTypeVP8):
 		return getVP8VideoParams(s)
 	default:
-		return 0, 0, errors.ErrUnsupportedDecodeFormat
+		return 0, 0, errors.ErrUnsupportedDecodeMimeType(mimeType)
 	}
 }
 

--- a/pkg/whip/whip_track_handler.go
+++ b/pkg/whip/whip_track_handler.go
@@ -325,7 +325,7 @@ func (t *whipTrackHandler) createDepacketizer() (rtp.Depacketizer, error) {
 		depacketizer = &codecs.OpusPacket{}
 
 	default:
-		return nil, errors.ErrUnsupportedDecodeFormat
+		return nil, errors.ErrUnsupportedDecodeMimeType(t.remoteTrack.Codec().MimeType)
 	}
 
 	return depacketizer, nil
@@ -354,7 +354,7 @@ func (t *whipTrackHandler) createJitterBuffer() (*jitter.Buffer, error) {
 		// No PLI for audio
 
 	default:
-		return nil, errors.ErrUnsupportedDecodeFormat
+		return nil, errors.ErrUnsupportedDecodeMimeType(t.remoteTrack.Codec().MimeType)
 	}
 
 	clockRate := t.remoteTrack.Codec().ClockRate


### PR DESCRIPTION
This seems needed to support HLS on linux.