### PR TITLE
Do not use sample providers in the go SDK

### DIFF
--- a/pkg/lksdk_output/lksdk_output.go
+++ b/pkg/lksdk_output/lksdk_output.go
@@ -17,6 +17,7 @@ package lksdk_output
 import (
 	"context"
 	"sync"
+	"sync/atomic"
 
 	"github.com/pion/rtcp"
 	"github.com/pion/webrtc/v3"
@@ -28,10 +29,33 @@ import (
 	lksdk "github.com/livekit/server-sdk-go"
 )
 
+type SampleProvider interface {
+	SetLocalTrack(track *lksdk.LocalTrack)
+	Close() error
+}
+
 type VideoSampleProvider interface {
-	lksdk.SampleProvider
+	SampleProvider
 
 	ForceKeyFrame() error
+}
+
+type PLIHandler struct {
+	p atomic.Pointer[VideoSampleProvider]
+}
+
+func (h *PLIHandler) HandlePLI() error {
+	p := h.p.Load()
+
+	if p != nil {
+		return (*p).ForceKeyFrame()
+	}
+
+	return nil
+}
+
+func (h *PLIHandler) SetSampleProvider(p VideoSampleProvider) {
+	h.p.Store(&p)
 }
 
 type LKSDKOutput struct {
@@ -40,7 +64,7 @@ type LKSDKOutput struct {
 	params *params.Params
 
 	lock    sync.Mutex
-	outputs []lksdk.SampleProvider
+	outputs []SampleProvider
 }
 
 func NewLKSDKOutput(ctx context.Context, p *params.Params) (*LKSDKOutput, error) {
@@ -76,7 +100,7 @@ func NewLKSDKOutput(ctx context.Context, p *params.Params) (*LKSDKOutput, error)
 	return s, nil
 }
 
-func (s *LKSDKOutput) AddAudioTrack(output lksdk.SampleProvider, mimeType string, disableDTX bool, stereo bool) error {
+func (s *LKSDKOutput) AddAudioTrack(mimeType string, disableDTX bool, stereo bool) (*lksdk.LocalTrack, error) {
 	opts := &lksdk.TrackPublicationOptions{
 		Name:       s.params.Audio.Name,
 		Source:     s.params.Audio.Source,
@@ -84,38 +108,30 @@ func (s *LKSDKOutput) AddAudioTrack(output lksdk.SampleProvider, mimeType string
 		Stereo:     stereo,
 	}
 
-	s.lock.Lock()
-	s.outputs = append(s.outputs, output)
-	s.lock.Unlock()
-
 	track, err := lksdk.NewLocalSampleTrack(webrtc.RTPCodecCapability{MimeType: mimeType})
 	if err != nil {
 		s.logger.Errorw("could not create audio track", err)
-		return err
+		return nil, err
 	}
 
-	onComplete := func() {
-		s.logger.Debugw("audio track write complete callback")
-	}
 	track.OnBind(func() {
-		s.logger.Debugw("audio track start write")
+		s.logger.Debugw("audio track bound")
+	})
 
-		// Start write is idempotent if the sample provider doesn't change
-		if err := track.StartWrite(output, onComplete); err != nil {
-			s.logger.Errorw("could not start writing audio track", err)
-		}
+	track.OnUnbind(func() {
+		s.logger.Debugw("audio track unbound")
 	})
 
 	_, err = s.room.LocalParticipant.PublishTrack(track, opts)
 	if err != nil {
 		s.logger.Errorw("could not publish audio track", err)
-		return err
+		return nil, err
 	}
 
-	return nil
+	return track, nil
 }
 
-func (s *LKSDKOutput) AddVideoTrack(outputs []VideoSampleProvider, layers []*livekit.VideoLayer, mimeType string) error {
+func (s *LKSDKOutput) AddVideoTrack(layers []*livekit.VideoLayer, mimeType string) ([]*lksdk.LocalTrack, []*PLIHandler, error) {
 	opts := &lksdk.TrackPublicationOptions{
 		Name:        s.params.Video.Name,
 		Source:      s.params.Video.Source,
@@ -125,25 +141,17 @@ func (s *LKSDKOutput) AddVideoTrack(outputs []VideoSampleProvider, layers []*liv
 
 	var err error
 
-	getOnComplete := func(layer *livekit.VideoLayer, output VideoSampleProvider) func() {
-		return func() {
-			s.logger.Debugw("video track layer write complete callback", "layer", layer.Quality.String())
-		}
-	}
-
 	tracks := make([]*lksdk.LocalSampleTrack, 0)
-	for i, layer := range layers {
-		output := outputs[i]
-
-		s.lock.Lock()
-		s.outputs = append(s.outputs, output)
-		s.lock.Unlock()
+	pliHandlers := make([]*PLIHandler, 0)
+	for _, layer := range layers {
+		pliHandler := &PLIHandler{}
+		pliHandlers = append(pliHandlers, pliHandler)
 
 		onRTCP := func(pkt rtcp.Packet) {
 			switch pkt.(type) {
 			case *rtcp.PictureLossIndication:
 				s.logger.Debugw("PLI received")
-				if err := output.ForceKeyFrame(); err != nil {
+				if err := pliHandler.HandlePLI(); err != nil {
 					s.logger.Errorw("could not force key frame", err)
 				}
 			}
@@ -154,30 +162,29 @@ func (s *LKSDKOutput) AddVideoTrack(outputs []VideoSampleProvider, layers []*liv
 			lksdk.WithRTCPHandler(onRTCP), lksdk.WithSimulcast(s.params.IngressId, layer))
 		if err != nil {
 			s.logger.Errorw("could not create video track", err)
-			return err
+			return nil, nil, err
 		}
 
-		onComplete := getOnComplete(layer, output)
 		localLayer := layer
 		track.OnBind(func() {
-			s.logger.Debugw("video track start write", "layer", localLayer.Quality.String())
-
-			if err := track.StartWrite(output, onComplete); err != nil {
-				s.logger.Errorw("could not start writing video track", err)
-			}
+			s.logger.Debugw("video track bound", "layer", localLayer.Quality.String())
 		})
+		track.OnUnbind(func() {
+			s.logger.Debugw("video track unbound", "layer", localLayer.Quality.String())
+		})
+
 		tracks = append(tracks, track)
 	}
 
 	_, err = s.room.LocalParticipant.PublishSimulcastTrack(tracks, opts)
 	if err != nil {
 		s.logger.Errorw("could not publish video track", err)
-		return err
+		return nil, nil, err
 	}
 
 	s.logger.Debugw("published video track")
 
-	return nil
+	return tracks, pliHandlers, nil
 }
 
 func (s *LKSDKOutput) Close() {

--- a/pkg/media/output.go
+++ b/pkg/media/output.go
@@ -17,7 +17,6 @@ package media
 import (
 	"fmt"
 	"io"
-	"sync/atomic"
 	"time"
 
 	"github.com/frostbyte73/core"
@@ -52,7 +51,7 @@ type Output struct {
 	outputSync         *utils.TrackOutputSynchronizer
 	trackStatsGatherer *stats.MediaTrackStatGatherer
 
-	localTrack atomic.Pointer[*lksdk.LocalTrack]
+	localTrack *lksdk.LocalTrack
 
 	closed core.Fuse
 }
@@ -359,9 +358,8 @@ func newOutput(outputSync *utils.TrackOutputSynchronizer, localTrack *lksdk.Loca
 		sink:       sink,
 		outputSync: outputSync,
 		closed:     core.NewFuse(),
+		localTrack: localTrack,
 	}
-
-	e.localTrack.Store(localTrack)
 
 	return e, nil
 }
@@ -429,10 +427,6 @@ func (e *Output) writeSample(s *media.Sample, pts time.Duration) error {
 	e.trackStatsGatherer.MediaReceived(int64(len(s.Data)))
 
 	return nil
-}
-
-func (e *Output) SetLocalTrack(track *lksdk.LocalTrack) {
-	e.localTrack.Store(track)
 }
 
 func (e *Output) Close() error {

--- a/pkg/media/output.go
+++ b/pkg/media/output.go
@@ -15,9 +15,9 @@
 package media
 
 import (
-	"context"
 	"fmt"
 	"io"
+	"sync/atomic"
 	"time"
 
 	"github.com/frostbyte73/core"
@@ -31,6 +31,7 @@ import (
 	"github.com/livekit/ingress/pkg/utils"
 	"github.com/livekit/protocol/livekit"
 	"github.com/livekit/protocol/logger"
+	lksdk "github.com/livekit/server-sdk-go"
 )
 
 const (
@@ -51,9 +52,9 @@ type Output struct {
 	outputSync         *utils.TrackOutputSynchronizer
 	trackStatsGatherer *stats.MediaTrackStatGatherer
 
-	samples chan *sample
-	closed  core.Fuse
-	flushed core.Fuse
+	localTrack atomic.Pointer[*lksdk.LocalTrack]
+
+	closed core.Fuse
 }
 
 type sample struct {
@@ -74,8 +75,8 @@ type AudioOutput struct {
 	codec livekit.AudioCodec
 }
 
-func NewVideoOutput(codec livekit.VideoCodec, layer *livekit.VideoLayer, outputSync *utils.TrackOutputSynchronizer, statsGatherer *stats.LocalMediaStatsGatherer) (*VideoOutput, error) {
-	e, err := newVideoOutput(codec, outputSync)
+func NewVideoOutput(codec livekit.VideoCodec, layer *livekit.VideoLayer, outputSync *utils.TrackOutputSynchronizer, localTrack *lksdk.LocalTrack, statsGatherer *stats.LocalMediaStatsGatherer) (*VideoOutput, error) {
+	e, err := newVideoOutput(codec, outputSync, localTrack)
 	if err != nil {
 		return nil, err
 	}
@@ -221,8 +222,8 @@ func NewVideoOutput(codec livekit.VideoCodec, layer *livekit.VideoLayer, outputS
 	return e, nil
 }
 
-func NewAudioOutput(options *livekit.IngressAudioEncodingOptions, outputSync *utils.TrackOutputSynchronizer, statsGatherer *stats.LocalMediaStatsGatherer) (*AudioOutput, error) {
-	e, err := newAudioOutput(options.AudioCodec, outputSync)
+func NewAudioOutput(options *livekit.IngressAudioEncodingOptions, outputSync *utils.TrackOutputSynchronizer, track *lksdk.LocalTrack, statsGatherer *stats.LocalMediaStatsGatherer) (*AudioOutput, error) {
+	e, err := newAudioOutput(options.AudioCodec, outputSync, track)
 	if err != nil {
 		return nil, err
 	}
@@ -310,8 +311,8 @@ func NewAudioOutput(options *livekit.IngressAudioEncodingOptions, outputSync *ut
 	return e, nil
 }
 
-func newVideoOutput(codec livekit.VideoCodec, outputSync *utils.TrackOutputSynchronizer) (*VideoOutput, error) {
-	e, err := newOutput(outputSync)
+func newVideoOutput(codec livekit.VideoCodec, outputSync *utils.TrackOutputSynchronizer, localTrack *lksdk.LocalTrack) (*VideoOutput, error) {
+	e, err := newOutput(outputSync, localTrack)
 	if err != nil {
 		return nil, err
 	}
@@ -329,8 +330,8 @@ func newVideoOutput(codec livekit.VideoCodec, outputSync *utils.TrackOutputSynch
 	return o, nil
 }
 
-func newAudioOutput(codec livekit.AudioCodec, outputSync *utils.TrackOutputSynchronizer) (*AudioOutput, error) {
-	e, err := newOutput(outputSync)
+func newAudioOutput(codec livekit.AudioCodec, outputSync *utils.TrackOutputSynchronizer, localTrack *lksdk.LocalTrack) (*AudioOutput, error) {
+	e, err := newOutput(outputSync, localTrack)
 	if err != nil {
 		return nil, err
 	}
@@ -348,7 +349,7 @@ func newAudioOutput(codec livekit.AudioCodec, outputSync *utils.TrackOutputSynch
 	return o, nil
 }
 
-func newOutput(outputSync *utils.TrackOutputSynchronizer) (*Output, error) {
+func newOutput(outputSync *utils.TrackOutputSynchronizer, localTrack *lksdk.LocalTrack) (*Output, error) {
 	sink, err := app.NewAppSink()
 	if err != nil {
 		return nil, err
@@ -357,10 +358,10 @@ func newOutput(outputSync *utils.TrackOutputSynchronizer) (*Output, error) {
 	e := &Output{
 		sink:       sink,
 		outputSync: outputSync,
-		samples:    make(chan *sample, 15),
 		closed:     core.NewFuse(),
-		flushed:    core.NewFuse(),
 	}
+
+	e.localTrack.Store(localTrack)
 
 	return e, nil
 }
@@ -396,27 +397,14 @@ func (e *Output) ForceKeyFrame() error {
 func (e *Output) handleEOS(_ *app.Sink) {
 	e.logger.Infow("app sink EOS")
 
-	e.Flush()
 	e.Close()
 }
 
-func (e *Output) Flush() {
-	select {
-	case e.samples <- nil:
-	case <-e.closed.Watch():
-	case <-time.After(time.Second):
-		e.logger.Errorw("output pipeline flush timed out", errors.New("could not enqueue EOS marker"))
-	}
-
-	select {
-	case <-e.flushed.Watch():
-	case <-e.closed.Watch():
-	case <-time.After(5 * time.Second):
-		e.logger.Errorw("output pipeline flush timed out", errors.New("flush timed out"))
-	}
-}
-
 func (e *Output) writeSample(s *media.Sample, pts time.Duration) error {
+
+	if e.closed.IsBroken() {
+		return io.EOF
+	}
 
 	// Synchronize the outputs before the network jitter buffer to avoid old samples stuck
 	// in the channel from increasing the whole pipeline delay.
@@ -426,52 +414,25 @@ func (e *Output) writeSample(s *media.Sample, pts time.Duration) error {
 	}
 	if drop {
 		e.logger.Debugw("Dropping sample", "timestamp", pts)
-		return nil
-	}
-
-	select {
-	case e.samples <- &sample{s, pts}:
-		return nil
-	case <-e.closed.Watch():
-		return io.EOF
-	default:
 		e.trackStatsGatherer.PacketLost(1)
-		// drop the sample if the output queue is full. This is needed if we are reconnecting.
 		return nil
 	}
-}
 
-func (e *Output) NextSample(ctx context.Context) (media.Sample, error) {
-	var s *sample
+	err = e.localTrack.WriteSample(*s, nil)
+	if err != nil {
+		fmt.Println("WRITE ERROR")
+		e.trackStatsGatherer.PacketLost(1)
 
-	for {
-		select {
-		case s = <-e.samples:
-		case <-e.closed.Watch():
-		case <-ctx.Done():
-		}
-
-		if s == nil {
-			e.flushed.Break()
-			return media.Sample{}, io.EOF
-		}
-
-		e.trackStatsGatherer.MediaReceived(int64(len(s.s.Data)))
-
-		return *s.s, nil
+		return nil
 	}
-}
 
-func (e *Output) OnBind() error {
-	e.logger.Infow("sample provider bound")
+	e.trackStatsGatherer.MediaReceived(int64(len(s.Data)))
 
 	return nil
 }
 
-func (e *Output) OnUnbind() error {
-	e.logger.Infow("sample provider unbound")
-
-	return nil
+func (e *Output) SetLocalTrack(track *lksdk.LocalTrack) {
+	e.localTrack.Store(track)
 }
 
 func (e *Output) Close() error {

--- a/pkg/media/output.go
+++ b/pkg/media/output.go
@@ -416,12 +416,11 @@ func (e *Output) writeSample(s *media.Sample, pts time.Duration) error {
 		return nil
 	}
 
+	// WriteSample seems to return successfully even if the Peer Connection disconnected.
+	// We need to return success to the caller even if the PC is disconnected to allow for reconnections
 	err = e.localTrack.WriteSample(*s, nil)
 	if err != nil {
-		fmt.Println("WRITE ERROR")
-		e.trackStatsGatherer.PacketLost(1)
-
-		return nil
+		return err
 	}
 
 	e.trackStatsGatherer.MediaReceived(int64(len(s.Data)))

--- a/pkg/media/webrtc_sink.go
+++ b/pkg/media/webrtc_sink.go
@@ -57,16 +57,20 @@ func NewWebRTCSink(ctx context.Context, p *params.Params, statsGatherer *stats.L
 }
 
 func (s *WebRTCSink) addAudioTrack() (*Output, error) {
-	output, err := NewAudioOutput(s.params.AudioEncodingOptions, s.outputSync.AddTrack(), s.statsGatherer)
+	err, track := s.sdkOut.AddAudioTrack(output, putils.GetMimeTypeForAudioCodec(s.params.AudioEncodingOptions.AudioCodec), s.params.AudioEncodingOptions.DisableDtx, s.params.AudioEncodingOptions.Channels > 1)
+	if err != nil {
+		return nil, err
+	}
+
+	output, err = NewAudioOutput(s.params.AudioEncodingOptions, s.outputSync.AddTrack(), track, s.statsGatherer)
 	if err != nil {
 		logger.Errorw("could not create output", err)
 		return nil, err
 	}
 
-	err = s.sdkOut.AddAudioTrack(output, putils.GetMimeTypeForAudioCodec(s.params.AudioEncodingOptions.AudioCodec), s.params.AudioEncodingOptions.DisableDtx, s.params.AudioEncodingOptions.Channels > 1)
-	if err != nil {
-		return nil, err
-	}
+	s.lock.Lock()
+	s.outputs = append(s.outputs, output)
+	s.lock.Unlock()
 
 	return output.Output, nil
 }
@@ -77,21 +81,26 @@ func (s *WebRTCSink) addVideoTrack(w, h int) ([]*Output, error) {
 
 	sortedLayers := filterAndSortLayersByQuality(s.params.VideoEncodingOptions.Layers, w, h)
 
-	var outLayers []*livekit.VideoLayer
-	for _, layer := range sortedLayers {
-		output, err := NewVideoOutput(s.params.VideoEncodingOptions.VideoCodec, layer, s.outputSync.AddTrack(), s.statsGatherer)
-		if err != nil {
-			return nil, err
-		}
-		outputs = append(outputs, output.Output)
-		sbArray = append(sbArray, output)
-		outLayers = append(outLayers, layer)
-	}
-
-	err := s.sdkOut.AddVideoTrack(sbArray, outLayers, putils.GetMimeTypeForVideoCodec(s.params.VideoEncodingOptions.VideoCodec))
+	tracks, pliHandlers, err := s.sdkOut.AddVideoTrack(sortedLayers, putils.GetMimeTypeForVideoCodec(s.params.VideoEncodingOptions.VideoCodec))
 	if err != nil {
 		return nil, err
 	}
+
+	for i, layer := range sortedLayers {
+		output, err := NewVideoOutput(s.params.VideoEncodingOptions.VideoCodec, layer, s.outputSync.AddTrack(), tracks[i], s.statsGatherer)
+		if err != nil {
+			return nil, err
+		}
+
+		pliHandlers[i].SetSampleProvider(output)
+
+		outputs = append(outputs, output.Output)
+		sbArray = append(sbArray, output)
+	}
+
+	s.lock.Lock()
+	s.outputs = append(s.outputs, outputs...)
+	s.lock.Unlock()
 
 	return outputs, nil
 }

--- a/pkg/whip/sdk_media_sink.go
+++ b/pkg/whip/sdk_media_sink.go
@@ -275,13 +275,11 @@ func (t *SDKMediaSinkTrack) PushSample(s *media.Sample, ts time.Duration) error 
 		return nil
 	}
 
+	// WriteSample seems to return successfully even if the Peer Connection disconnected.
+	// We need to return success to the caller even if the PC is disconnected to allow for reconnections
 	err = localTrack.WriteSample(*s, nil)
 	if err != nil {
-		if g != nil {
-			g.PacketLost(1)
-		}
-
-		return nil
+		return err
 	}
 
 	if g != nil {

--- a/pkg/whip/sdk_media_sink.go
+++ b/pkg/whip/sdk_media_sink.go
@@ -154,6 +154,9 @@ func (sp *SDKMediaSink) ensureAudioTracksInitialized(s *media.Sample, t *SDKMedi
 	if err != nil {
 		return false, err
 	}
+
+	sp.sdkOutput.AddOutputs(t)
+
 	sp.sinkInitialized = true
 	return sp.sinkInitialized, nil
 }
@@ -171,6 +174,7 @@ func (sp *SDKMediaSink) ensureVideoTracksInitialized(s *media.Sample, t *SDKMedi
 	}
 
 	layers := []*livekit.VideoLayer{}
+	sbArray := []lksdk_output.SampleProvider{}
 
 	for _, track := range sp.tracks {
 		if track.width != 0 && track.height != 0 {
@@ -180,6 +184,7 @@ func (sp *SDKMediaSink) ensureVideoTracksInitialized(s *media.Sample, t *SDKMedi
 				Quality: track.quality,
 			})
 		}
+		sbArray = append(sbArray, track)
 	}
 
 	// Simulcast
@@ -204,6 +209,8 @@ func (sp *SDKMediaSink) ensureVideoTracksInitialized(s *media.Sample, t *SDKMedi
 	if err != nil {
 		return false, err
 	}
+
+	sp.sdkOutput.AddOutputs(sbArray...)
 
 	for i, t := range sp.tracks {
 		t.localTrack = tracks[i]

--- a/pkg/whip/sdk_media_sink.go
+++ b/pkg/whip/sdk_media_sink.go
@@ -215,7 +215,7 @@ func (sp *SDKMediaSink) ensureTrackInitialized(s *media.Sample) error {
 		sp.params.SetInputVideoState(context.Background(), videoState, true)
 
 		sp.logger.Infow("adding video track", "width", w, "height", h, "codec", mimeType)
-		sp.sdkOutput.AddVideoTrack(s, layers, mimeType)
+		tracks, err := sp.sdkOutput.AddVideoTrack(s, layers, mimeType)
 	}
 
 	sp.trackInitialized = true


### PR DESCRIPTION
Caling WriteSample directly on the local track makes dealing with disconnections and A/V sync easier.

WriteSample succeeds even if the PeerConnection is disconnected. This means that the output lost packet count gathered by the service is inaccurate.