### PR TITLE
Connect to room asynchronously

### DIFF
--- a/pkg/media/output.go
+++ b/pkg/media/output.go
@@ -459,8 +459,9 @@ func (e *Output) writeSample(s *media.Sample, pts time.Duration) error {
 
 	localTrack := e.localTrack.Load()
 	if localTrack == nil {
-		e.logger.Infow("localTrack unexpectedly nil")
-		return psrpc.NewErrorf(psrpc.Internal, "localTrack unexpectedly nil")
+		err = psrpc.NewErrorf(psrpc.Internal, "localTrack unexpectedly nil")
+		e.logger.Warnw("unable to write sample", err)
+		return err
 	}
 
 	// WriteSample seems to return successfully even if the Peer Connection disconnected.

--- a/pkg/media/pipeline.go
+++ b/pkg/media/pipeline.go
@@ -75,18 +75,22 @@ func New(ctx context.Context, conf *config.Config, params *params.Params, g *sta
 		return nil, err
 	}
 
-	sink, err := NewWebRTCSink(ctx, params, g)
-	if err != nil {
-		return nil, err
-	}
-
 	p := &Pipeline{
 		Params:      params,
 		pipeline:    pipeline,
-		sink:        sink,
 		input:       input,
 		pipelineErr: make(chan error, 1),
 	}
+
+	sink, err := NewWebRTCSink(ctx, params, func() {
+		if p.loop != nil {
+			p.loop.Quit()
+		}
+	}, g)
+	if err != nil {
+		return nil, err
+	}
+	p.sink = sink
 
 	input.OnOutputReady(p.onOutputReady)
 


### PR DESCRIPTION
Drop media while waiting for connection, after the decoder to avoid having to wait for a key frame once dropping stops.

This prevents media from accumulating in the pipeline while waiting for the room connection.
