### PR TITLE
Version 1.4.3

### DIFF
--- a/version/version.go
+++ b/version/version.go
@@ -14,4 +14,4 @@
 
 package version
 
-const Version = "1.4.2"
+const Version = "1.4.3"


### PR DESCRIPTION
 ## Changelog

 ### Fixed

- Log WHIP user agent and RTP packet if unmarshalling fails (#274)
- Tear down full WHIP session of one of the track handlers fail (#277)
- nil check on SDK teardown (#278)
- Be sure to cancel input initialization when shutting down an ingress during start up (#279)
- Update module golang.org/x/image to v0.18.0 [SECURITY] (#286)
- Implement KillIngressSession rpc (#282)
- Report failure when WHIP handler fails to initialize (#285)
- Stop output sdk watchdog on teardown (#287)
- Update go-gst (#305)
- Update to pion/webrtc v4 (#312)