### PR TITLE
Remove actions/cache usage in workflows/build.yaml

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -31,14 +31,5 @@ jobs:
         with:
           lfs: true
 
-      - uses: actions/cache@v4
-        with:
-          path: |
-            ~/go/pkg/mod
-            ~/go/bin
-            ~/bin/protoc
-            ~/.cache
-          key: ingress
-
       - name: Build docker image
         run: docker build -t ingress -f ./build/ingress/Dockerfile --build-arg GOVERSION=$GOVERSION --build-arg GSTVERSION=$GSTVERSION .


### PR DESCRIPTION
As in https://github.com/livekit/sip/pull/275, the usage of actions/cache here is not really doing anything - proposing removing.