### PR TITLE
Add a media watchdog

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -96,7 +96,7 @@ func main() {
 	}
 
 	if err := app.Run(os.Args); err != nil {
-		fmt.Println(err)
+		logger.Infow("process excited", "error", err)
 	}
 }
 

--- a/pkg/lksdk_output/lksdk_output.go
+++ b/pkg/lksdk_output/lksdk_output.go
@@ -145,6 +145,11 @@ func NewLKSDKOutput(ctx context.Context, onDisconnected func(), p *params.Params
 		}
 
 		s.closeOutput()
+
+		if onDisconnected != nil {
+			onDisconnected()
+		}
+
 	}, watchdogDeadline)
 
 	cb := lksdk.NewRoomCallback()
@@ -352,6 +357,10 @@ func (s *LKSDKOutput) closeOutput() {
 
 	if s.trackWatchdog != nil {
 		s.trackWatchdog.Stop()
+	}
+
+	if s.mediaWatchdog != nil {
+		s.mediaWatchdog.Stop()
 	}
 
 	if s.room != nil {

--- a/pkg/lksdk_output/media_watchdog.go
+++ b/pkg/lksdk_output/media_watchdog.go
@@ -1,0 +1,61 @@
+// Copyright 2025 LiveKit, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package lksdk_output
+
+import (
+	"sync/atomic"
+	"time"
+
+	"github.com/frostbyte73/core"
+)
+
+type MediaWatchdog struct {
+	bytesSinceLastCheck atomic.Int64
+
+	done core.Fuse
+}
+
+func NewMediaWatchdog(onFire func(), deadline time.Duration) *MediaWatchdog {
+	w := &MediaWatchdog{}
+
+	ticker := time.NewTicker(deadline)
+
+	go func() {
+		for {
+			select {
+			case <-w.done.Watch():
+				ticker.Stop()
+				return
+			case <-ticker.C:
+				b := w.bytesSinceLastCheck.Swap(0)
+				if b == 0 {
+					// Do not fire the watchdog again
+					ticker.Stop()
+					onFire()
+				}
+			}
+		}
+	}()
+
+	return w
+}
+
+func (w *MediaWatchdog) Stop() {
+	w.done.Break()
+}
+
+func (w *MediaWatchdog) MediaReceived(b int64) {
+	w.bytesSinceLastCheck.Add(b)
+}

--- a/pkg/lksdk_output/media_watchdog_test.go
+++ b/pkg/lksdk_output/media_watchdog_test.go
@@ -1,0 +1,64 @@
+// Copyright 2025 LiveKit, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package lksdk_output
+
+import (
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/frostbyte73/core"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMediaWatchdog(t *testing.T) {
+	triggered := testWatchDog(t, 10)
+	require.False(t, triggered)
+
+	triggered = testWatchDog(t, 0)
+	require.True(t, triggered)
+
+}
+
+func testWatchDog(t *testing.T, mediaReceived int64) bool {
+	var triggered atomic.Bool
+	var done core.Fuse
+
+	w := NewMediaWatchdog(func() {
+		triggered.Store(true)
+	}, 100*time.Millisecond)
+
+	ticker := time.NewTicker(10 * time.Millisecond)
+	go func() {
+		for {
+			select {
+			case <-done.Watch():
+				return
+			case <-ticker.C:
+				if mediaReceived > 0 {
+					w.MediaReceived(mediaReceived)
+				}
+			}
+		}
+	}()
+
+	time.Sleep(time.Second)
+
+	done.Break()
+	ticker.Stop()
+	w.Stop()
+
+	return triggered.Load()
+}

--- a/pkg/lksdk_output/track_watchdog.go
+++ b/pkg/lksdk_output/track_watchdog.go
@@ -19,7 +19,7 @@ import (
 	"time"
 )
 
-type Watchdog struct {
+type TrackWatchdog struct {
 	deadline time.Duration
 	onFire   func()
 
@@ -30,15 +30,15 @@ type Watchdog struct {
 	started            bool
 }
 
-func NewWatchdog(onFire func(), deadline time.Duration) *Watchdog {
-	return &Watchdog{
+func NewTrackWatchdog(onFire func(), deadline time.Duration) *TrackWatchdog {
+	return &TrackWatchdog{
 		onFire:   onFire,
 		deadline: deadline,
 		started:  true,
 	}
 }
 
-func (w *Watchdog) TrackAdded() {
+func (w *TrackWatchdog) TrackAdded() {
 	w.trackLock.Lock()
 	defer w.trackLock.Unlock()
 
@@ -47,7 +47,7 @@ func (w *Watchdog) TrackAdded() {
 	w.updateTimer()
 }
 
-func (w *Watchdog) TrackBound() {
+func (w *TrackWatchdog) TrackBound() {
 	w.trackLock.Lock()
 	defer w.trackLock.Unlock()
 
@@ -56,7 +56,7 @@ func (w *Watchdog) TrackBound() {
 	w.updateTimer()
 }
 
-func (w *Watchdog) TrackUnbound() {
+func (w *TrackWatchdog) TrackUnbound() {
 	w.trackLock.Lock()
 	defer w.trackLock.Unlock()
 
@@ -65,7 +65,7 @@ func (w *Watchdog) TrackUnbound() {
 	w.updateTimer()
 }
 
-func (w *Watchdog) Stop() {
+func (w *TrackWatchdog) Stop() {
 	w.trackLock.Lock()
 	defer w.trackLock.Unlock()
 
@@ -75,7 +75,7 @@ func (w *Watchdog) Stop() {
 }
 
 // Must be called locked
-func (w *Watchdog) updateTimer() {
+func (w *TrackWatchdog) updateTimer() {
 	timerMustBeActive := w.started && w.boundTrackCount < w.expectedTrackCount
 
 	if w.timer == nil && timerMustBeActive {

--- a/pkg/media/output.go
+++ b/pkg/media/output.go
@@ -26,12 +26,12 @@ import (
 	"github.com/pion/webrtc/v4/pkg/media"
 
 	"github.com/livekit/ingress/pkg/errors"
+	"github.com/livekit/ingress/pkg/lksdk_output"
 	"github.com/livekit/ingress/pkg/stats"
 	"github.com/livekit/ingress/pkg/utils"
 	"github.com/livekit/protocol/livekit"
 	"github.com/livekit/protocol/logger"
 	"github.com/livekit/psrpc"
-	lksdk "github.com/livekit/server-sdk-go/v2"
 )
 
 const (
@@ -52,7 +52,7 @@ type Output struct {
 	outputSync         *utils.TrackOutputSynchronizer
 	trackStatsGatherer *stats.MediaTrackStatGatherer
 
-	localTrack   atomic.Pointer[lksdk.LocalTrack]
+	localTrack   atomic.Pointer[lksdk_output.LocalTrack]
 	stopDropping func()
 
 	closed core.Fuse
@@ -394,7 +394,7 @@ func newOutput(outputSync *utils.TrackOutputSynchronizer) (*Output, error) {
 	return e, nil
 }
 
-func (o *Output) SinkReady(localTrack *lksdk.LocalTrack) {
+func (o *Output) SinkReady(localTrack *lksdk_output.LocalTrack) {
 	o.localTrack.Store(localTrack)
 
 	if o.stopDropping != nil {

--- a/pkg/media/webrtc_sink.go
+++ b/pkg/media/webrtc_sink.go
@@ -31,7 +31,6 @@ import (
 	"github.com/livekit/protocol/logger"
 	"github.com/livekit/protocol/tracer"
 	putils "github.com/livekit/protocol/utils"
-	lksdk "github.com/livekit/server-sdk-go/v2"
 )
 
 type WebRTCSink struct {
@@ -124,7 +123,7 @@ func (s *WebRTCSink) addAudioTrack() (*Output, error) {
 		}
 
 		if sdkOut != nil {
-			var track *lksdk.LocalTrack
+			var track *lksdk_output.LocalTrack
 			track, err = sdkOut.AddAudioTrack(putils.GetMimeTypeForAudioCodec(s.params.AudioEncodingOptions.AudioCodec), s.params.AudioEncodingOptions.DisableDtx, s.params.AudioEncodingOptions.Channels > 1)
 			if err != nil {
 				return
@@ -180,7 +179,7 @@ func (s *WebRTCSink) addVideoTrack(w, h int) ([]*Output, error) {
 		}
 
 		if sdkOut != nil {
-			var tracks []*lksdk.LocalTrack
+			var tracks []*lksdk_output.LocalTrack
 			var pliHandlers []*lksdk_output.RTCPHandler
 
 			tracks, pliHandlers, err = sdkOut.AddVideoTrack(sortedLayers, putils.GetMimeTypeForVideoCodec(s.params.VideoEncodingOptions.VideoCodec))

--- a/pkg/whip/sdk_media_sink.go
+++ b/pkg/whip/sdk_media_sink.go
@@ -40,7 +40,6 @@ import (
 	"github.com/livekit/protocol/livekit"
 	"github.com/livekit/protocol/logger"
 	"github.com/livekit/psrpc"
-	lksdk "github.com/livekit/server-sdk-go/v2"
 )
 
 var (
@@ -52,7 +51,7 @@ type SDKMediaSinkTrack struct {
 	width, height uint
 
 	trackStatsGatherer *stats.MediaTrackStatGatherer
-	localTrack         *lksdk.LocalTrack
+	localTrack         *lksdk_output.LocalTrack
 
 	stateLock        sync.Mutex
 	sendRTCPUpStream func(pkt rtcp.Packet)


### PR DESCRIPTION
This adds a media watchdog at the input of the go SDK (so at the tail of the pipeline). This is needed because in some cases, such as SRT input. gstreamer will retry to connect for ever without emitting any event about the failure to connect. This will close the ingress if no media is received on any track for 1 min.