### PR TITLE
back down synchronizer wait time if the processing pipeline becomes too long

### DIFF
--- a/pkg/lksdk_output/lksdk_output.go
+++ b/pkg/lksdk_output/lksdk_output.go
@@ -41,6 +41,7 @@ const (
 )
 
 type SampleProvider interface {
+	QueueLength() int
 	Close() error
 }
 type KeyFrameEmitter interface {
@@ -341,6 +342,15 @@ func (s *LKSDKOutput) AddOutputs(o ...SampleProvider) {
 	s.lock.Lock()
 	s.outputs = append(s.outputs, o...)
 	s.lock.Unlock()
+}
+
+func (s *LKSDKOutput) GetOutputs() []SampleProvider {
+	s.lock.Lock()
+	ret := make([]SampleProvider, len(s.outputs))
+	copy(ret, s.outputs)
+	s.lock.Unlock()
+
+	return ret
 }
 
 func (s *LKSDKOutput) closeOutput() {

--- a/pkg/media/output.go
+++ b/pkg/media/output.go
@@ -398,6 +398,8 @@ func newOutput(outputSync *utils.TrackOutputSynchronizer, isPlayingTooSlow func(
 		isPlayingTooSlow: isPlayingTooSlow,
 	}
 
+	e.start()
+
 	return e, nil
 }
 
@@ -481,8 +483,7 @@ func (e *Output) writeSample(s *sample) error {
 	return nil
 }
 
-// TODO call Start, get min queue length
-func (e *Output) Start() {
+func (e *Output) start() {
 	go func() {
 		for {
 			s, err := e.queue.PopFront()

--- a/pkg/media/webrtc_sink.go
+++ b/pkg/media/webrtc_sink.go
@@ -152,6 +152,11 @@ func (s *WebRTCSink) isPlayingTooSlow() bool {
 		return false
 	}
 
+	if !s.params.Live {
+		// output back pressure sets the play rate for VOD
+		return false
+	}
+
 	o := sdkOut.GetOutputs()
 	minQueueLength := math.MaxInt
 	for _, out := range o {

--- a/pkg/media/webrtc_sink.go
+++ b/pkg/media/webrtc_sink.go
@@ -16,6 +16,7 @@ package media
 
 import (
 	"context"
+	"math"
 	"sync"
 
 	"github.com/frostbyte73/core"
@@ -31,6 +32,10 @@ import (
 	"github.com/livekit/protocol/logger"
 	"github.com/livekit/protocol/tracer"
 	putils "github.com/livekit/protocol/utils"
+)
+
+const (
+	targetMinQueueLength = 2
 )
 
 type WebRTCSink struct {
@@ -92,7 +97,7 @@ func NewWebRTCSink(ctx context.Context, p *params.Params, onFailure func(), stat
 }
 
 func (s *WebRTCSink) addAudioTrack() (*Output, error) {
-	output, err := NewAudioOutput(s.params.AudioEncodingOptions, s.outputSync.AddTrack(), s.statsGatherer)
+	output, err := NewAudioOutput(s.params.AudioEncodingOptions, s.outputSync.AddTrack(), s.isPlayingTooSlow, s.statsGatherer)
 	if err != nil {
 		logger.Errorw("could not create output", err)
 		return nil, err
@@ -138,6 +143,29 @@ func (s *WebRTCSink) addAudioTrack() (*Output, error) {
 	return output.Output, nil
 }
 
+func (s *WebRTCSink) isPlayingTooSlow() bool {
+	s.lock.Lock()
+	sdkOut := s.sdkOut
+	s.lock.Unlock()
+
+	if sdkOut == nil {
+		return false
+	}
+
+	o := sdkOut.GetOutputs()
+	minQueueLength := math.MaxInt
+	for _, out := range o {
+		minQueueLength = min(minQueueLength, out.QueueLength())
+	}
+
+	if minQueueLength > targetMinQueueLength {
+		logger.Debugw("playing too slow", "minQueueLength", minQueueLength)
+		return true
+	}
+
+	return false
+}
+
 func (s *WebRTCSink) addVideoTrack(w, h int) ([]*Output, error) {
 	outputs := make([]*Output, 0)
 	sbArray := make([]lksdk_output.SampleProvider, 0)
@@ -145,7 +173,7 @@ func (s *WebRTCSink) addVideoTrack(w, h int) ([]*Output, error) {
 	sortedLayers := filterAndSortLayersByQuality(s.params.VideoEncodingOptions.Layers, w, h)
 
 	for _, layer := range sortedLayers {
-		output, err := NewVideoOutput(s.params.VideoEncodingOptions.VideoCodec, layer, s.outputSync.AddTrack(), s.statsGatherer)
+		output, err := NewVideoOutput(s.params.VideoEncodingOptions.VideoCodec, layer, s.outputSync.AddTrack(), s.isPlayingTooSlow, s.statsGatherer)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/params/params.go
+++ b/pkg/params/params.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"os"
 	"path"
+	"strings"
 	"sync"
 	"time"
 
@@ -50,6 +51,7 @@ type Params struct {
 
 	AudioEncodingOptions *livekit.IngressAudioEncodingOptions
 	VideoEncodingOptions *livekit.IngressVideoEncodingOptions
+	Live                 bool
 
 	// connection info
 	WsUrl string
@@ -151,6 +153,7 @@ func GetParams(ctx context.Context, psrpcClient rpc.IOInfoClient, conf *config.C
 		Config:               conf,
 		AudioEncodingOptions: audioEncodingOptions,
 		VideoEncodingOptions: videoEncodingOptions,
+		Live:                 getLive(info),
 		Token:                token,
 		WsUrl:                wsUrl,
 		RelayToken:           relayToken,
@@ -177,6 +180,19 @@ func UpdateTranscodingEnabled(info *livekit.IngressInfo) {
 	default:
 		t := true
 		info.EnableTranscoding = &t
+	}
+}
+
+func getLive(info *livekit.IngressInfo) bool {
+	switch info.InputType {
+	case livekit.IngressInput_URL_INPUT:
+		if strings.HasPrefix(info.Url, "http://") || strings.HasPrefix(info.Url, "https://") {
+			return false
+		} else {
+			return true
+		}
+	default:
+		return true
 	}
 }
 

--- a/pkg/utils/blocking_queue.go
+++ b/pkg/utils/blocking_queue.go
@@ -1,0 +1,59 @@
+// Copyright 2023 LiveKit, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package utils
+
+import (
+	"sync/atomic"
+
+	"github.com/frostbyte73/core"
+	"github.com/livekit/ingress/pkg/errors"
+)
+
+type BlockingQueue[T any] struct {
+	queue chan T
+	size  atomic.Int32
+
+	closed core.Fuse
+}
+
+func NewBlockingQueue[T any](capacity int) *BlockingQueue[T] {
+	return &BlockingQueue[T]{
+		queue: make(chan T, capacity),
+	}
+}
+
+func (b *BlockingQueue[T]) PushBack(item T) {
+	select {
+	case b.queue <- item:
+		// Small race here
+		b.size.Add(1)
+	case <-b.closed.Watch():
+	}
+}
+
+func (b *BlockingQueue[T]) PopFront() (T, error) {
+	select {
+	case item := <-b.queue:
+		// Small race here
+		b.size.Add(-1)
+		return item, nil
+	case <-b.closed.Watch():
+		return *new(T), errors.ErrIngressClosing
+	}
+}
+
+func (b *BlockingQueue[T]) Close() {
+	b.closed.Break()
+}

--- a/pkg/utils/output_synchronizer.go
+++ b/pkg/utils/output_synchronizer.go
@@ -27,7 +27,6 @@ import (
 
 const (
 	leeway                       = 100 * time.Millisecond
-	maxTargetWaitDuration        = 100 * time.Millisecond
 	waitDurationAdjustmentAmount = 10 * time.Millisecond
 )
 

--- a/pkg/whip/sdk_media_sink.go
+++ b/pkg/whip/sdk_media_sink.go
@@ -301,6 +301,11 @@ func (t *SDKMediaSinkTrack) PushRTCP(pkts []rtcp.Packet) error {
 	return nil
 }
 
+func (sp *SDKMediaSinkTrack) QueueLength() int {
+	// No buffering
+	return 0
+}
+
 func (t *SDKMediaSinkTrack) Close() error {
 	return t.sink.Close()
 }


### PR DESCRIPTION
Currently, the output synchronizer increases the reference/wait time if a packet arrives later than expected at the output to compensate drifts, stalls or other processing hiccups. The reference time is however never brought back down if the clock drifts the other way, or the total pipeline processing time decreases. In the case of SRT where there is a guaranteed latency between client and server, this can cause the input buffer to fill up to its max value, causing essentially a deadlock. 

This patch adds a queue we can monitor between the appsink and the go SDK. We measure the length of this queue and if it grows to more than 2 buffers, we decrease the synchronizer wait time in quantum of 10ms until the queue shortens below the threshold. 

The above is disabled to HLS as for VOD (or live with a large buffer) content, the back pressure at the output is needed and the pipeline is expected to hold a lot of data.