### PR TITLE
Fix typo in error messages

### DIFF
--- a/pkg/errors/errors.go
+++ b/pkg/errors/errors.go
@@ -46,9 +46,9 @@ var (
 	ErrPrerollBufferReset           = psrpc.NewErrorf(psrpc.Internal, "preroll buffer reset")
 	ErrInvalidSimulcast             = psrpc.NewErrorf(psrpc.NotAcceptable, "invalid simulcast configuration")
 	ErrSimulcastTranscode           = psrpc.NewErrorf(psrpc.NotAcceptable, "simulcast is not supported when transcoding")
-	ErrRoomDisconnected             = psrpc.NewErrorf(psrpc.NotAcceptable, "room disonnected")
+	ErrRoomDisconnected             = psrpc.NewErrorf(psrpc.NotAcceptable, "room disconnected")
 	ErrInvalidWHIPRestartRequest    = psrpc.NewErrorf(psrpc.InvalidArgument, "whip restart request was invalid")
-	ErrRoomDisconnectedUnexpectedly = RetryableError{psrpc.NewErrorf(psrpc.Unavailable, "room disonnected unexpectedly")}
+	ErrRoomDisconnectedUnexpectedly = RetryableError{psrpc.NewErrorf(psrpc.Unavailable, "room disconnected unexpectedly")}
 )
 
 type RetryableError struct {


### PR DESCRIPTION
Update misspelled `disonnected` to `disconnected`