### PR TITLE
Log caps existance when connecting to caps notifier

### DIFF
--- a/pkg/media/pipeline.go
+++ b/pkg/media/pipeline.go
@@ -120,6 +120,9 @@ func (p *Pipeline) onOutputReady(pad *gst.Pad, kind types.StreamKind) {
 		}
 	}()
 
+	currentCaps := pad.GetCurrentCaps()
+	logger.Debugw("output ready", "kind", kind, "capsAlreadySet", currentCaps != nil)
+
 	_, err = pad.Connect("notify::caps", func(gPad *gst.GhostPad, _ *glib.ParamSpec) {
 		p.onParamsReady(kind, gPad)
 	})


### PR DESCRIPTION
To get more info for ingresses which started failing with staging e2e runs. I suspect race condition - where caps are already set before we subscribe for caps notifier - in which case we won't get the callback at all.