### PR TITLE
Fix WHIP H264 appsrc caps alignment

### DIFF
--- a/pkg/media/whip/appsrc.go
+++ b/pkg/media/whip/appsrc.go
@@ -203,7 +203,7 @@ func getCapsForCodec(mimeType string) (*gst.Caps, error) {
 
 	switch mt {
 	case strings.ToLower(webrtc.MimeTypeH264):
-		return gst.NewCapsFromString("video/x-h264,stream-format=byte-stream,alignment=nal"), nil
+		return gst.NewCapsFromString("video/x-h264,stream-format=byte-stream,alignment=au"), nil
 	case strings.ToLower(webrtc.MimeTypeVP8):
 		return gst.NewCapsFromString("video/x-vp8"), nil
 	case strings.ToLower(webrtc.MimeTypeOpus):

--- a/pkg/media/whip/appsrc_test.go
+++ b/pkg/media/whip/appsrc_test.go
@@ -1,0 +1,43 @@
+// Copyright 2023 LiveKit, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package whip
+
+import (
+	"testing"
+
+	"github.com/go-gst/go-gst/gst"
+	"github.com/pion/webrtc/v4"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetCapsForCodecH264UsesAccessUnitAlignment(t *testing.T) {
+	gst.Init(nil)
+
+	caps, err := getCapsForCodec(webrtc.MimeTypeH264)
+	require.NoError(t, err)
+	require.NotNil(t, caps)
+
+	structure := caps.GetStructureAt(0)
+	require.NotNil(t, structure)
+	require.Equal(t, "video/x-h264", structure.Name())
+
+	streamFormat, err := structure.GetValue("stream-format")
+	require.NoError(t, err)
+	require.Equal(t, "byte-stream", streamFormat)
+
+	alignment, err := structure.GetValue("alignment")
+	require.NoError(t, err)
+	require.Equal(t, "au", alignment)
+}


### PR DESCRIPTION
## Summary

Updates WHIP H.264 appsrc caps to use access-unit alignment instead of NAL alignment.

WHIP H.264 packets are depacketized and grouped into media samples before being pushed into GStreamer. Those samples are access-unit-like Annex-B buffers, but the appsrc caps currently advertise `alignment=nal`. With GStreamer 1.26.7 this can fail in the downstream `decodebin3`/`parsebin` path with:

```text
GstParseBin:parsebin0/GstH264Parse:h264parse1: No caps set
```

Using `alignment=au` matches the sample boundary that the WHIP relay already writes into appsrc.

## Validation

- Added a focused unit test for the H.264 caps emitted by `getCapsForCodec`.
- Ran:

```bash
go test ./pkg/media/whip
go test ./pkg/media/...
go test ./pkg/whip/... ./pkg/media/...
```

I also reproduced the GStreamer behavior locally in the LiveKit ingress container: the same Annex-B H.264 stream failed with `alignment=nal` and decoded successfully with `alignment=au`.
