### PR TITLE
Add publish_status metric with HTTPError-based status classification

### DIFF
--- a/pkg/errors/errors.go
+++ b/pkg/errors/errors.go
@@ -16,7 +16,10 @@ package errors
 
 import (
 	"errors"
+	"fmt"
 	"io"
+	"net/http"
+	"strings"
 
 	"github.com/go-gst/go-gst/gst"
 	"google.golang.org/grpc/status"
@@ -73,6 +76,48 @@ func (err RetryableError) GRPCStatus() *status.Status {
 
 func (err RetryableError) Unwrap() error {
 	return err.psrpcErr
+}
+
+type HTTPError struct {
+	StatusCode int
+	err        error
+}
+
+func NewHTTPError(statusCode int, err error) *HTTPError {
+	return &HTTPError{
+		StatusCode: statusCode,
+		err:        err,
+	}
+}
+
+const maxErrorBodyLen = 200
+
+// NewHTTPErrorFromResponse builds an HTTPError from a failed HTTP response. The
+// error message is derived from the first maxErrorBodyLen characters of the
+// response body, falling back to a generic message when the body is empty.
+func NewHTTPErrorFromResponse(resp *http.Response) *HTTPError {
+	msg := "server returned an error"
+	// A UTF-8 rune is at most 4 bytes, so reading (maxErrorBodyLen+1)*4 bytes is
+	// enough to render up to maxErrorBodyLen characters and detect truncation.
+	if b, err := io.ReadAll(io.LimitReader(resp.Body, (maxErrorBodyLen+1)*4)); err == nil {
+		if body := strings.TrimSpace(string(b)); body != "" {
+			if r := []rune(body); len(r) > maxErrorBodyLen {
+				msg = string(r[:maxErrorBodyLen]) + "... (truncated)"
+			} else {
+				msg = body
+			}
+		}
+	}
+
+	return NewHTTPError(resp.StatusCode, New(msg))
+}
+
+func (e *HTTPError) Error() string {
+	return fmt.Sprintf("HTTP error %d: %s", e.StatusCode, e.err.Error())
+}
+
+func (e *HTTPError) Unwrap() error {
+	return e.err
 }
 
 func New(err string) error {

--- a/pkg/errors/errors_test.go
+++ b/pkg/errors/errors_test.go
@@ -1,0 +1,95 @@
+// Copyright 2026 LiveKit, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package errors
+
+import (
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+	"unicode/utf8"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestHTTPError(t *testing.T) {
+	inner := New("not found")
+	err := NewHTTPError(http.StatusNotFound, inner)
+
+	require.Equal(t, http.StatusNotFound, err.StatusCode)
+
+	// Error() includes the status code.
+	require.Equal(t, "HTTP error 404: not found", err.Error())
+
+	// Unwrap() exposes the wrapped error for errors.Is/As.
+	require.ErrorIs(t, err, inner)
+
+	var httpErr *HTTPError
+	require.True(t, As(err, &httpErr))
+	require.Equal(t, http.StatusNotFound, httpErr.StatusCode)
+}
+
+func newResponse(statusCode int, body string) *http.Response {
+	return &http.Response{
+		StatusCode: statusCode,
+		Body:       io.NopCloser(strings.NewReader(body)),
+	}
+}
+
+func TestNewHTTPErrorFromResponse(t *testing.T) {
+	t.Run("uses body as message", func(t *testing.T) {
+		err := NewHTTPErrorFromResponse(newResponse(http.StatusBadRequest, "bad request payload"))
+		require.Equal(t, http.StatusBadRequest, err.StatusCode)
+		require.Equal(t, "HTTP error 400: bad request payload", err.Error())
+	})
+
+	t.Run("trims surrounding whitespace", func(t *testing.T) {
+		err := NewHTTPErrorFromResponse(newResponse(http.StatusBadRequest, "  oops\n"))
+		require.Equal(t, "HTTP error 400: oops", err.Error())
+	})
+
+	t.Run("empty body falls back to generic message", func(t *testing.T) {
+		err := NewHTTPErrorFromResponse(newResponse(http.StatusInternalServerError, ""))
+		require.Equal(t, "HTTP error 500: server returned an error", err.Error())
+	})
+
+	t.Run("whitespace-only body falls back to generic message", func(t *testing.T) {
+		err := NewHTTPErrorFromResponse(newResponse(http.StatusInternalServerError, "   \n\t"))
+		require.Equal(t, "HTTP error 500: server returned an error", err.Error())
+	})
+
+	t.Run("long body is truncated", func(t *testing.T) {
+		body := strings.Repeat("a", maxErrorBodyLen+50)
+		err := NewHTTPErrorFromResponse(newResponse(http.StatusBadGateway, body))
+		expected := strings.Repeat("a", maxErrorBodyLen) + "... (truncated)"
+		require.Equal(t, "HTTP error 502: "+expected, err.Error())
+	})
+
+	t.Run("body exactly at limit is not truncated", func(t *testing.T) {
+		body := strings.Repeat("a", maxErrorBodyLen)
+		err := NewHTTPErrorFromResponse(newResponse(http.StatusBadGateway, body))
+		require.Equal(t, "HTTP error 502: "+body, err.Error())
+	})
+
+	t.Run("multibyte body truncates on rune boundary", func(t *testing.T) {
+		// Each "é" is 2 bytes; ensure we count characters, not bytes, and never
+		// split a rune.
+		body := strings.Repeat("é", maxErrorBodyLen+50)
+		err := NewHTTPErrorFromResponse(newResponse(http.StatusBadGateway, body))
+		expected := strings.Repeat("é", maxErrorBodyLen) + "... (truncated)"
+		require.Equal(t, "HTTP error 502: "+expected, err.Error())
+		require.True(t, utf8.ValidString(err.Error()))
+	})
+}

--- a/pkg/rtmp/server.go
+++ b/pkg/rtmp/server.go
@@ -42,10 +42,15 @@ import (
 type RTMPServer struct {
 	server   *rtmp.Server
 	handlers sync.Map
+	monitor  *stats.Monitor
 }
 
 func NewRTMPServer() *RTMPServer {
 	return &RTMPServer{}
+}
+
+func (s *RTMPServer) SetMonitor(monitor *stats.Monitor) {
+	s.monitor = monitor
 }
 
 func (s *RTMPServer) Start(conf *config.Config, onPublish func(streamKey, resourceId string) (*params.Params, *stats.LocalMediaStatsGatherer, error)) error {
@@ -72,6 +77,7 @@ func (s *RTMPServer) Start(conf *config.Config, onPublish func(streamKey, resour
 			lf := l.WithFields(conf.GetLoggerFields())
 
 			h := NewRTMPHandler()
+			h.SetMonitor(s.monitor)
 			h.OnPublishCallback(func(streamKey, resourceId string) (*params.Params, *stats.LocalMediaStatsGatherer, error) {
 				var params *params.Params
 				var stats *stats.LocalMediaStatsGatherer
@@ -158,8 +164,9 @@ type RTMPHandler struct {
 	keyFrameFound bool
 	mediaBuffer   *utils.PrerollBuffer
 
-	log    logger.Logger
-	closed core.Fuse
+	log     logger.Logger
+	closed  core.Fuse
+	monitor *stats.Monitor
 
 	onPublish func(streamKey, resourceId string) (*params.Params, *stats.LocalMediaStatsGatherer, error)
 	onClose   func(resourceId string)
@@ -181,6 +188,10 @@ func NewRTMPHandler() *RTMPHandler {
 	return h
 }
 
+func (h *RTMPHandler) SetMonitor(monitor *stats.Monitor) {
+	h.monitor = monitor
+}
+
 func (h *RTMPHandler) OnPublishCallback(cb func(streamKey, resourceId string) (*params.Params, *stats.LocalMediaStatsGatherer, error)) {
 	h.onPublish = cb
 }
@@ -189,7 +200,11 @@ func (h *RTMPHandler) OnCloseCallback(cb func(resourceId string)) {
 	h.onClose = cb
 }
 
-func (h *RTMPHandler) OnPublish(_ *rtmp.StreamContext, _ uint32, cmd *rtmpmsg.NetStreamPublish) error {
+func (h *RTMPHandler) OnPublish(_ *rtmp.StreamContext, _ uint32, cmd *rtmpmsg.NetStreamPublish) (err error) {
+	defer func() {
+		h.monitor.RecordPublicationResult("rtmp", err)
+	}()
+
 	// Reject a connection when PublishingName is empty
 	if cmd.PublishingName == "" {
 		return errors.ErrMissingStreamKey

--- a/pkg/service/service.go
+++ b/pkg/service/service.go
@@ -104,6 +104,13 @@ func NewService(
 ) (*Service, error) {
 	monitor := stats.NewMonitor()
 
+	if rtmpSrv != nil {
+		rtmpSrv.SetMonitor(monitor)
+	}
+	if whipSrv != nil {
+		whipSrv.SetMonitor(monitor)
+	}
+
 	s := &Service{
 		conf:          conf,
 		monitor:       monitor,

--- a/pkg/stats/monitor.go
+++ b/pkg/stats/monitor.go
@@ -163,8 +163,15 @@ func (m *Monitor) RecordPublicationResult(ingressType string, err error) {
 }
 
 func publicationStatus(err error) string {
+	const (
+		publicationStatusSuccess  = "success"
+		publicationStatus4xx      = "4xx"
+		publicationStatus5xx      = "5xx"
+		publicationStatusInternal = "internal"
+	)
+
 	if err == nil {
-		return "success"
+		return publicationStatusSuccess
 	}
 
 	// Only an actual 5xx HTTP status from the upstream response is counted as a
@@ -173,30 +180,30 @@ func publicationStatus(err error) string {
 	if errors.As(err, &httpErr) {
 		switch code := httpErr.StatusCode; {
 		case code >= 400 && code < 500:
-			return "4xx"
+			return publicationStatus4xx
 		case code >= 500:
-			return "5xx"
+			return publicationStatus5xx
 		default:
-			return "internal"
+			return publicationStatusInternal
 		}
 	}
 
 	var psrpcErr psrpc.Error
 	if !errors.As(err, &psrpcErr) {
 		// Unstructured error, treat as an internal failure
-		return "internal"
+		return publicationStatusInternal
 	}
 
 	switch psrpcErr.Code() {
 	case psrpc.Internal, psrpc.Unknown, psrpc.DataLoss:
-		return "internal"
+		return publicationStatusInternal
 	}
 
 	if code := psrpcErr.ToHttp(); code >= 400 && code < 500 {
-		return "4xx"
+		return publicationStatus4xx
 	}
 
-	return "internal"
+	return publicationStatusInternal
 }
 
 func (m *Monitor) checkCPUConfig() error {

--- a/pkg/stats/monitor.go
+++ b/pkg/stats/monitor.go
@@ -27,6 +27,7 @@ import (
 	"github.com/livekit/protocol/livekit"
 	"github.com/livekit/protocol/logger"
 	"github.com/livekit/protocol/utils/hwstats"
+	"github.com/livekit/psrpc"
 
 	"github.com/livekit/ingress/pkg/config"
 	"github.com/livekit/ingress/pkg/errors"
@@ -42,9 +43,10 @@ type Monitor struct {
 	cpuCostConfig  config.CPUCostConfig
 	maxCost        float64
 
-	promCPULoad       prometheus.Gauge
-	requestGauge      *prometheus.GaugeVec
-	promNodeAvailable prometheus.GaugeFunc
+	promCPULoad            prometheus.Gauge
+	requestGauge           *prometheus.GaugeVec
+	promNodeAvailable      prometheus.GaugeFunc
+	promPublicationCounter *prometheus.CounterVec
 
 	cpuStats *hwstats.CPUStats
 
@@ -100,8 +102,14 @@ func (m *Monitor) Start(conf *config.Config) error {
 		Name:        "requests",
 		ConstLabels: prometheus.Labels{"node_id": conf.NodeID},
 	}, []string{"type", "transcoding"})
+	m.promPublicationCounter = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Namespace:   "livekit",
+		Subsystem:   "ingress",
+		Name:        "publish_status",
+		ConstLabels: prometheus.Labels{"node_id": conf.NodeID},
+	}, []string{"type", "status"})
 
-	prometheus.MustRegister(m.promCPULoad, m.promNodeAvailable, m.requestGauge)
+	prometheus.MustRegister(m.promCPULoad, m.promNodeAvailable, m.requestGauge, m.promPublicationCounter)
 
 	m.started.Break()
 
@@ -137,6 +145,47 @@ func (m *Monitor) Stop() {
 	prometheus.Unregister(m.promCPULoad)
 	prometheus.Unregister(m.requestGauge)
 	prometheus.Unregister(m.promNodeAvailable)
+	prometheus.Unregister(m.promPublicationCounter)
+}
+
+// RecordPublicationResult records the outcome of a stream publication attempt,
+// bucketing it as success/4xx/5xx/internal. It is a no-op if the monitor has
+// not been started (e.g. in standalone test binaries).
+func (m *Monitor) RecordPublicationResult(ingressType string, err error) {
+	if m == nil || m.promPublicationCounter == nil {
+		return
+	}
+
+	m.promPublicationCounter.With(prometheus.Labels{
+		"type":   ingressType,
+		"status": publicationStatus(err),
+	}).Inc()
+}
+
+func publicationStatus(err error) string {
+	if err == nil {
+		return "success"
+	}
+
+	var psrpcErr psrpc.Error
+	if !errors.As(err, &psrpcErr) {
+		// Unstructured error, treat as an internal failure
+		return "internal"
+	}
+
+	switch psrpcErr.Code() {
+	case psrpc.Internal, psrpc.Unknown, psrpc.DataLoss:
+		return "internal"
+	}
+
+	switch code := psrpcErr.ToHttp(); {
+	case code >= 400 && code < 500:
+		return "4xx"
+	case code >= 500:
+		return "5xx"
+	default:
+		return "internal"
+	}
 }
 
 func (m *Monitor) checkCPUConfig() error {

--- a/pkg/stats/monitor.go
+++ b/pkg/stats/monitor.go
@@ -167,6 +167,20 @@ func publicationStatus(err error) string {
 		return "success"
 	}
 
+	// Only an actual 5xx HTTP status from the upstream response is counted as a
+	// 5xx error. psrpc errors are classified as either 4xx or internal.
+	var httpErr *errors.HTTPError
+	if errors.As(err, &httpErr) {
+		switch code := httpErr.StatusCode; {
+		case code >= 400 && code < 500:
+			return "4xx"
+		case code >= 500:
+			return "5xx"
+		default:
+			return "internal"
+		}
+	}
+
 	var psrpcErr psrpc.Error
 	if !errors.As(err, &psrpcErr) {
 		// Unstructured error, treat as an internal failure
@@ -178,14 +192,11 @@ func publicationStatus(err error) string {
 		return "internal"
 	}
 
-	switch code := psrpcErr.ToHttp(); {
-	case code >= 400 && code < 500:
+	if code := psrpcErr.ToHttp(); code >= 400 && code < 500 {
 		return "4xx"
-	case code >= 500:
-		return "5xx"
-	default:
-		return "internal"
 	}
+
+	return "internal"
 }
 
 func (m *Monitor) checkCPUConfig() error {

--- a/pkg/stats/monitor_test.go
+++ b/pkg/stats/monitor_test.go
@@ -1,0 +1,86 @@
+// Copyright 2026 LiveKit, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package stats
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/livekit/psrpc"
+
+	"github.com/livekit/ingress/pkg/errors"
+)
+
+func TestPublicationStatus(t *testing.T) {
+	cases := []struct {
+		name     string
+		err      error
+		expected string
+	}{
+		{
+			name:     "nil error is success",
+			err:      nil,
+			expected: "success",
+		},
+		{
+			name:     "unstructured error is internal",
+			err:      errors.New("boom"),
+			expected: "internal",
+		},
+		{
+			name:     "HTTPError 4xx is 4xx",
+			err:      errors.NewHTTPError(http.StatusBadRequest, errors.New("bad request")),
+			expected: "4xx",
+		},
+		{
+			name:     "HTTPError 5xx is 5xx",
+			err:      errors.NewHTTPError(http.StatusBadGateway, errors.New("upstream down")),
+			expected: "5xx",
+		},
+		{
+			name:     "HTTPError non-error status is internal",
+			err:      errors.NewHTTPError(http.StatusOK, errors.New("weird")),
+			expected: "internal",
+		},
+		{
+			name:     "HTTPError 5xx wrapped in psrpc is still 5xx",
+			err:      psrpc.NewError(psrpc.Internal, errors.NewHTTPError(http.StatusServiceUnavailable, errors.New("unavailable"))),
+			expected: "5xx",
+		},
+		{
+			name:     "psrpc 4xx code is 4xx",
+			err:      psrpc.NewErrorf(psrpc.InvalidArgument, "bad input"),
+			expected: "4xx",
+		},
+		{
+			name:     "psrpc internal code is internal",
+			err:      psrpc.NewErrorf(psrpc.Internal, "boom"),
+			expected: "internal",
+		},
+		{
+			name:     "psrpc 5xx code is internal, not 5xx",
+			err:      psrpc.NewErrorf(psrpc.Unavailable, "unavailable"),
+			expected: "internal",
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			require.Equal(t, c.expected, publicationStatus(c.err))
+		})
+	}
+}

--- a/pkg/whip/server.go
+++ b/pkg/whip/server.go
@@ -64,6 +64,12 @@ type WHIPServer struct {
 	handlers     map[string]WHIPHandler
 
 	getWhipProxyEnabled func(ctx context.Context, featureFlags map[string]string) bool
+
+	monitor *stats.Monitor
+}
+
+func (s *WHIPServer) SetMonitor(monitor *stats.Monitor) {
+	s.monitor = monitor
 }
 
 type WHIPHandler interface {
@@ -317,15 +323,19 @@ func (s *WHIPServer) handleError(err error, w http.ResponseWriter) {
 	}
 }
 
-func (s *WHIPServer) handleNewWhipClient(w http.ResponseWriter, r *http.Request, streamKey string) error {
+func (s *WHIPServer) handleNewWhipClient(w http.ResponseWriter, r *http.Request, streamKey string) (err error) {
 	// TODO return ETAG header
+
+	defer func() {
+		s.monitor.RecordPublicationResult("whip", err)
+	}()
 
 	vars := mux.Vars(r)
 	app := vars["app"]
 
 	sdpOffer := bytes.Buffer{}
 
-	_, err := io.Copy(&sdpOffer, r.Body)
+	_, err = io.Copy(&sdpOffer, r.Body)
 	if err != nil {
 		return err
 	}

--- a/pkg/whip/whip_proxy_handler.go
+++ b/pkg/whip/whip_proxy_handler.go
@@ -32,6 +32,7 @@ import (
 	"github.com/livekit/psrpc"
 	google_protobuf2 "google.golang.org/protobuf/types/known/emptypb"
 
+	"github.com/livekit/ingress/pkg/errors"
 	"github.com/livekit/ingress/pkg/params"
 	"github.com/livekit/ingress/pkg/stats"
 	"github.com/livekit/ingress/pkg/types"
@@ -143,7 +144,7 @@ func (h *proxyWhipHandler) Init(_ context.Context, sdpOffer string) (string, err
 
 	code := getErrorCodeForStatus(resp.StatusCode)
 	if code != psrpc.OK {
-		return "", psrpc.NewErrorf(code, "WHIP resource creation failed on SFU. code=%d", resp.StatusCode)
+		return "", psrpc.NewError(code, errors.NewHTTPErrorFromResponse(resp))
 	}
 
 	locationHeader := resp.Header.Get("Location")
@@ -232,7 +233,7 @@ func (h *proxyWhipHandler) close(isRTCClosed bool) {
 
 	code := getErrorCodeForStatus(resp.StatusCode)
 	if code != psrpc.OK {
-		err = psrpc.NewErrorf(code, "WHIP resource deletion failed on SFU. code=%d", resp.StatusCode)
+		err = psrpc.NewError(code, errors.NewHTTPErrorFromResponse(resp))
 		h.logger.Warnw("WHIP delete request returned error status code", err, "statusCode", resp.StatusCode)
 		return
 	}
@@ -314,7 +315,7 @@ func (h *proxyWhipHandler) ICERestartWHIPResource(_ context.Context, req *rpc.IC
 
 	code := getErrorCodeForStatus(resp.StatusCode)
 	if code != psrpc.OK {
-		return nil, psrpc.NewErrorf(code, "WHIP resource patch failed on SFU. code=%d", resp.StatusCode)
+		return nil, psrpc.NewError(code, errors.NewHTTPErrorFromResponse(resp))
 	}
 
 	sdpResponse, err := io.ReadAll(resp.Body)


### PR DESCRIPTION
## Summary

Adds a `publish_status` Prometheus metric that buckets stream publication outcomes as `success` / `4xx` / `5xx` / `internal`, and introduces a reusable `HTTPError` type so the real upstream HTTP status can drive that classification.

## Changes

- **`pkg/errors`**: new `HTTPError` type carrying a `StatusCode`, with `NewHTTPError` and `NewHTTPErrorFromResponse` constructors. `NewHTTPErrorFromResponse` derives the message from the first 200 characters of the response body (falling back to `"server returned an error"` for empty bodies, marking truncation otherwise). `Error()` includes the status code and `Unwrap()` cooperates with `errors.Is/As`.
- **`pkg/whip/whip_proxy_handler.go`**: the three functions that make HTTP calls to the SFU (`Init`, `close`, `ICERestartWHIPResource`) now wrap failed responses with `psrpc.NewError(code, errors.NewHTTPErrorFromResponse(resp))`, preserving both the psrpc code and the recoverable HTTP status.
- **`pkg/stats/monitor.go`**: `publicationStatus` retrieves the HTTP status from a wrapped `HTTPError` when present. Only an actual 5xx `HTTPError` status is counted as `5xx`; psrpc errors are classified as either `4xx` or `internal`.

## Tests

- `pkg/errors/errors_test.go`: `HTTPError` behavior and `NewHTTPErrorFromResponse` (body-as-message, whitespace trimming, empty/whitespace fallback, truncation, exact-limit, multibyte rune-boundary truncation).
- `pkg/stats/monitor_test.go`: `publicationStatus` classification across nil, unstructured, `HTTPError` 4xx/5xx, psrpc-wrapped `HTTPError`, and psrpc-code cases (incl. psrpc 503 → `internal`, not `5xx`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
