### PR TITLE
Fix GStreamer-CRITICAL when attaching latency meta to non-writable buffers

### DIFF
--- a/pkg/media/input.go
+++ b/pkg/media/input.go
@@ -303,6 +303,8 @@ func (i *Input) addStatsCollectionProbe(kind types.StreamKind) {
 			g := i.trackStatsGatherer[kind]
 
 			if padKind == kind {
+				var lastAttached time.Time
+
 				pad.AddProbe(gst.PadProbeTypeBuffer, func(_ *gst.Pad, info *gst.PadProbeInfo) gst.PadProbeReturn {
 					buffer := info.GetBuffer()
 					if buffer == nil {
@@ -316,7 +318,10 @@ func (i *Input) addStatsCollectionProbe(kind types.StreamKind) {
 
 					// mark the packet with the current time to be able to calculate packet processing latency at output stage
 					now := time.Now()
-					buffer.AddReferenceTimestampMeta(i.latencyCaps, gst.ClockTime(uint64(now.UnixNano())), gst.ClockTime(0))
+					if now.Sub(lastAttached) >= latencySampleInterval && buffer.IsWritable() {
+						buffer.AddReferenceTimestampMeta(i.latencyCaps, gst.ClockTime(uint64(now.UnixNano())), gst.ClockTime(0))
+						lastAttached = now
+					}
 
 					return gst.PadProbeOK
 				})


### PR DESCRIPTION
The stats probe from #392 attaches a reference timestamp meta to every buffer at the multiqueue sink pad, but `gst_buffer_add_meta` requires a writable buffer. Depending on the upstream element, buffers there may hold extra refs, causing per-buffer `gst_buffer_is_writable` criticals in some sessions.

- Only attach the meta to writable buffers.
- Sample at attach time (once per 500ms) instead of stamping every buffer - the consumer already throttles to that interval, so per-buffer metas were wasted work.

Sessions where no buffer is ever writable still miss the latency metric (as before, just without log spam); fixing those would need `MakeWritable` + buffer replacement support in the gst-go fork.