### PR TITLE
Pass handler params via env vars, not cmdline

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -58,31 +58,40 @@ func main() {
 				Description: "runs a request in a new process",
 				Flags: []cli.Flag{
 					&cli.StringFlag{
-						Name: "info",
+						Name:    "info",
+						Sources: cli.EnvVars("INGRESS_HANDLER_INFO"),
 					},
 					&cli.StringFlag{
-						Name: "config-body",
+						Name:    "config-body",
+						Sources: cli.EnvVars("INGRESS_HANDLER_CONFIG_BODY"),
 					},
 					&cli.StringFlag{
-						Name: "token",
+						Name:    "token",
+						Sources: cli.EnvVars("INGRESS_HANDLER_TOKEN"),
 					},
 					&cli.StringFlag{
-						Name: "project-id",
+						Name:    "project-id",
+						Sources: cli.EnvVars("INGRESS_HANDLER_PROJECT_ID"),
 					},
 					&cli.StringFlag{
-						Name: "relay-token",
+						Name:    "relay-token",
+						Sources: cli.EnvVars("INGRESS_HANDLER_RELAY_TOKEN"),
 					},
 					&cli.StringFlag{
-						Name: "ws-url",
+						Name:    "ws-url",
+						Sources: cli.EnvVars("INGRESS_HANDLER_WS_URL"),
 					},
 					&cli.StringFlag{
-						Name: "feature-flags",
+						Name:    "feature-flags",
+						Sources: cli.EnvVars("INGRESS_HANDLER_FEATURE_FLAGS"),
 					},
 					&cli.StringFlag{
-						Name: "logging-fields",
+						Name:    "logging-fields",
+						Sources: cli.EnvVars("INGRESS_HANDLER_LOGGING_FIELDS"),
 					},
 					&cli.StringFlag{
-						Name: "extra-params",
+						Name:    "extra-params",
+						Sources: cli.EnvVars("INGRESS_HANDLER_EXTRA_PARAMS"),
 					},
 				},
 				Action: runHandler,

--- a/pkg/service/cmd.go
+++ b/pkg/service/cmd.go
@@ -17,6 +17,7 @@ package service
 import (
 	"context"
 	"encoding/json"
+	"os"
 	"os/exec"
 
 	"google.golang.org/protobuf/encoding/protojson"
@@ -69,35 +70,20 @@ func NewCmd(_ context.Context, p *params.Params) (*exec.Cmd, error) {
 		loggingFields = string(b)
 	}
 
-	args := []string{
-		"run-handler",
-		"--config-body", string(confString),
-		"--info", string(infoString),
-		"--project-id", p.ProjectID,
-		"--relay-token", p.RelayToken,
-	}
-
-	if p.WsUrl != "" {
-		args = append(args, "--ws-url", p.WsUrl)
-	}
-	if p.Token != "" {
-		args = append(args, "--token", p.Token)
-	}
-	if extraParamsString != "" {
-		args = append(args, "--extra-params", extraParamsString)
-	}
-	if featureFlags != "" {
-		args = append(args, "--feature-flags", featureFlags)
-	}
-	if loggingFields != "" {
-		args = append(args, "--logging-fields", loggingFields)
-	}
-
-	cmd := exec.Command("ingress",
-		args...,
+	cmd := exec.Command("ingress", "run-handler")
+	cmd.Dir = "/"
+	cmd.Env = append(os.Environ(),
+		"INGRESS_HANDLER_CONFIG_BODY="+string(confString),
+		"INGRESS_HANDLER_INFO="+string(infoString),
+		"INGRESS_HANDLER_PROJECT_ID="+p.ProjectID,
+		"INGRESS_HANDLER_RELAY_TOKEN="+p.RelayToken,
+		"INGRESS_HANDLER_WS_URL="+p.WsUrl,
+		"INGRESS_HANDLER_TOKEN="+p.Token,
+		"INGRESS_HANDLER_EXTRA_PARAMS="+extraParamsString,
+		"INGRESS_HANDLER_FEATURE_FLAGS="+featureFlags,
+		"INGRESS_HANDLER_LOGGING_FIELDS="+loggingFields,
 	)
 
-	cmd.Dir = "/"
 	l := utils.NewHandlerLogger(p.State.ResourceId, p.IngressId)
 	cmd.Stdout = l
 	cmd.Stderr = l


### PR DESCRIPTION
## Summary

The per-ingress params are passed to the hidden `run-handler` child process as command-line args (`--config-body`, `--info`, `--token`, `--project-id`, `--relay-token`, `--ws-url`, `--extra-params`, `--feature-flags`, `--logging-fields`). Several carry secrets — `token`, `relay-token`, and the config body — so they leak to any local user via `ps` / `/proc/<pid>/cmdline`.

This moves every payload onto the child process **environment** instead:

- `pkg/service/cmd.go` — `NewCmd` sets `INGRESS_HANDLER_*` vars on `cmd.Env` (inheriting `os.Environ()`) instead of building an arg list. Values that were previously appended only when non-empty are now always set; an empty var reads back as an empty flag, so handler behaviour is unchanged.
- `cmd/server/main.go` — each `run-handler` flag gains the matching `INGRESS_HANDLER_*` env var as a `Source`, so it's populated from the environment. `runHandler` is unchanged (`c.String(...)` resolves the env source transparently), and the flags still work for manual invocation.

Env vars also sidestep `ARG_MAX` limits on the (potentially large) config + info payloads.

Same change as livekit/egress#1298.

🤖 Generated with [Claude Code](https://claude.com/claude-code)