### PR TITLE
Add least-privilege permissions to GH Actions workflows

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -19,6 +19,10 @@ on:
     branches: [ main ]
   pull_request:
     branches: [ main ]
+
+permissions:
+  contents: read
+
 env:
   GOVERSION: "1.25.0"
   GSTVERSION: "1.26.7"

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -22,6 +22,9 @@ on:
     tags:
       - 'v*.*.*'
 
+permissions:
+  contents: read
+
 env:
   GOVERSION: "1.25.0"
   GSTVERSION: "1.26.7"

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -18,6 +18,9 @@ on:
   pull_request:
     branches: [ main ]
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: namespace-profile-8vcpu-cache


### PR DESCRIPTION
## Summary
Declare `permissions: contents: read` on the `build`, `docker`, and `test` workflows so they no longer inherit the repository's default `GITHUB_TOKEN` scopes.

These jobs only check out code and build/push Docker images (Docker Hub auth uses separate secrets, not `GITHUB_TOKEN`), so read-only contents access is sufficient. `slack-notifier.yaml` already declares scoped permissions and is unchanged.

This is GitHub's recommended hardening for Actions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)