### PR TITLE
Create handler IPC endpoints before advertising session RPC topics

### DIFF
--- a/pkg/ipc/conn.go
+++ b/pkg/ipc/conn.go
@@ -96,7 +96,10 @@ func (ihc *IngressHandlerClientWrapper) Close() error {
 }
 
 func StartHandlerServer(tmpDir string, h IngressHandlerServer) error {
-	listener, err := net.Listen(network, getHandlerSocketAddress(tmpDir))
+	socketAddr := getHandlerSocketAddress(tmpDir)
+	os.Remove(socketAddr)
+
+	listener, err := net.Listen(network, socketAddr)
 	if err != nil {
 		return err
 	}

--- a/pkg/ipc/conn_test.go
+++ b/pkg/ipc/conn_test.go
@@ -1,0 +1,37 @@
+// Copyright 2026 LiveKit, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ipc
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/livekit/ingress/pkg/testutil"
+)
+
+type testHandler struct {
+	UnimplementedIngressHandlerServer
+}
+
+func TestStartHandlerServerRebindsExistingSocket(t *testing.T) {
+	tmpDir := testutil.ShortTempDir(t)
+
+	require.NoError(t, StartHandlerServer(tmpDir, &testHandler{}))
+
+	// a relaunched handler must be able to bind after a previous process
+	// died without unlinking its socket
+	require.NoError(t, StartHandlerServer(tmpDir, &testHandler{}))
+}

--- a/pkg/service/process_manager.go
+++ b/pkg/service/process_manager.go
@@ -24,6 +24,7 @@ import (
 	"time"
 
 	"github.com/frostbyte73/core"
+	"google.golang.org/grpc"
 	"google.golang.org/protobuf/types/known/emptypb"
 
 	"github.com/livekit/protocol/livekit"
@@ -44,12 +45,14 @@ const (
 type process struct {
 	sessionCloser
 
-	params     *params.Params
-	retryCount int
-	cmd        *exec.Cmd
-	grpcClient atomic.Pointer[ipc.IngressHandlerClient]
-	rpcServer  rpc.IngressHandlerServer
-	closed     core.Fuse
+	params           *params.Params
+	retryCount       int
+	cmd              *exec.Cmd
+	grpcClient       atomic.Pointer[ipc.IngressHandlerClient]
+	ipcHandlerClient *ipc.IngressHandlerClientWrapper
+	ipcServiceServer *grpc.Server
+	rpcServer        rpc.IngressHandlerServer
+	closed           core.Fuse
 }
 
 type ProcessManager struct {
@@ -110,29 +113,62 @@ func (s *ProcessManager) startIngress(ctx context.Context, p *params.Params, clo
 		},
 	}
 
-	rpcServer, err := rpc.NewIngressHandlerServer(h, s.bus)
+	if p.TmpDir != "" {
+		err := os.MkdirAll(p.TmpDir, 0755)
+		if err != nil {
+			logger.Errorw("failed creating handler temp directory", err, "path", p.TmpDir)
+			return err
+		}
+	}
+
+	// on any startup failure below, remove the temp directory and the sockets
+	// it contains; on success runHandler owns the cleanup
+	started := false
+	defer func() {
+		if !started && p.TmpDir != "" {
+			os.RemoveAll(p.TmpDir)
+		}
+	}()
+
+	// create the IPC endpoints before advertising the RPC topics so that
+	// requests dispatched during handler startup can always resolve a client
+	ipcServiceServer, err := ipc.StartServiceServer(p.TmpDir, s)
 	if err != nil {
 		return err
 	}
+	h.ipcServiceServer = ipcServiceServer
 
-	utils.RegisterIngressRpcHandlers(rpcServer, p.IngressInfo)
-	s.sm.IngressStarted(p.IngressInfo, h)
+	ipcHandlerClient, err := ipc.GetHandlerClient(p.TmpDir)
+	if err != nil {
+		ipcServiceServer.Stop()
+		return err
+	}
+	h.ipcHandlerClient = ipcHandlerClient
+	h.grpcClient.Store(&ipcHandlerClient.IngressHandlerClient)
 
+	rpcServer, err := rpc.NewIngressHandlerServer(h, s.bus)
+	if err != nil {
+		ipcHandlerClient.Close()
+		ipcServiceServer.Stop()
+		return err
+	}
 	h.rpcServer = rpcServer
+
+	if err := utils.RegisterIngressRpcHandlers(rpcServer, p.IngressInfo); err != nil {
+		utils.DeregisterIngressRpcHandlers(rpcServer, p.IngressInfo)
+		ipcHandlerClient.Close()
+		ipcServiceServer.Stop()
+		return err
+	}
+
+	s.sm.IngressStarted(p.IngressInfo, h)
 
 	s.mu.Lock()
 	s.activeHandlers[p.State.ResourceId] = h
 	s.mu.Unlock()
 
-	if p.TmpDir != "" {
-		err := os.MkdirAll(p.TmpDir, 0755)
-		if err != nil {
-			logger.Errorw("failed creating halder temp directory", err, "path", p.TmpDir)
-			return err
-		}
-	}
-
 	go s.runHandler(ctx, h, p)
+	started = true
 
 	return nil
 }
@@ -141,25 +177,17 @@ func (s *ProcessManager) runHandler(ctx context.Context, h *process, p *params.P
 	_, span := tracer.Start(ctx, "Service.runHandler")
 	defer span.End()
 
-	grpcServer, err := ipc.StartServiceServer(p.TmpDir, s)
-	if err != nil {
-		span.RecordError(err)
-		logger.Errorw("could start grpc service", err)
-
-		return
-	}
-
 	defer func() {
 		h.closed.Break()
 		s.sm.IngressEnded(h.params.State.ResourceId)
 
-		grpcServer.Stop()
+		utils.DeregisterIngressRpcHandlers(h.rpcServer, p.IngressInfo)
+		h.ipcHandlerClient.Close()
+		h.ipcServiceServer.Stop()
 
 		if p.TmpDir != "" {
 			os.RemoveAll(p.TmpDir)
 		}
-
-		utils.DeregisterIngressRpcHandlers(h.rpcServer, p.IngressInfo)
 
 		s.mu.Lock()
 		delete(s.activeHandlers, h.params.State.ResourceId)
@@ -178,18 +206,6 @@ func (s *ProcessManager) runHandler(ctx context.Context, h *process, p *params.P
 func (s *ProcessManager) runHandlerTry(ctx context.Context, h *process, p *params.Params) (bool, error) {
 	_, span := tracer.Start(ctx, "Service.runHandlerTry")
 	defer span.End()
-
-	var err error
-	grpcClient, err := ipc.GetHandlerClient(h.params.TmpDir)
-	if err != nil {
-		span.RecordError(err)
-		logger.Errorw("could not dial grpc handler", err)
-		return false, err
-
-	}
-	defer grpcClient.Close()
-
-	h.grpcClient.Store(&grpcClient.IngressHandlerClient)
 
 	cmd, err := s.newCmd(ctx, p)
 	if err != nil {
@@ -249,7 +265,7 @@ func (p *process) UpdateIngress(ctx context.Context, _ *livekit.UpdateIngressReq
 		return nil, errors.ErrIngressNotFound
 	}
 
-	resp, err := (*grpcClient).KillIngress(ctx, &ipc.KillIngressRequest{})
+	resp, err := (*grpcClient).KillIngress(ctx, &ipc.KillIngressRequest{}, grpc.WaitForReady(true))
 
 	if err != nil {
 		return nil, err
@@ -264,7 +280,7 @@ func (p *process) DeleteIngress(ctx context.Context, _ *livekit.DeleteIngressReq
 		return nil, errors.ErrIngressNotFound
 	}
 
-	resp, err := (*grpcClient).KillIngress(ctx, &ipc.KillIngressRequest{})
+	resp, err := (*grpcClient).KillIngress(ctx, &ipc.KillIngressRequest{}, grpc.WaitForReady(true))
 
 	if err != nil {
 		return nil, err
@@ -279,7 +295,7 @@ func (p *process) DeleteWHIPResource(ctx context.Context, _ *rpc.DeleteWHIPResou
 		return nil, errors.ErrIngressNotFound
 	}
 
-	_, err := (*grpcClient).KillIngress(ctx, &ipc.KillIngressRequest{})
+	_, err := (*grpcClient).KillIngress(ctx, &ipc.KillIngressRequest{}, grpc.WaitForReady(true))
 
 	if err != nil {
 		return nil, err

--- a/pkg/service/process_manager_test.go
+++ b/pkg/service/process_manager_test.go
@@ -1,0 +1,108 @@
+// Copyright 2026 LiveKit, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package service
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/livekit/ingress/pkg/params"
+	"github.com/livekit/ingress/pkg/stats"
+	"github.com/livekit/ingress/pkg/testutil"
+	"github.com/livekit/protocol/livekit"
+	"github.com/livekit/protocol/rpc"
+	"github.com/livekit/psrpc"
+)
+
+func newTestProcessManager(t *testing.T) (*ProcessManager, psrpc.MessageBus) {
+	bus := psrpc.NewLocalMessageBus()
+	sm := NewSessionManager(stats.NewMonitor(), nil)
+	pm, err := NewProcessManager(sm, nil, bus, nil)
+	require.NoError(t, err)
+	return pm, bus
+}
+
+func newTestParams(tmpDir string) *params.Params {
+	return &params.Params{
+		IngressInfo: &livekit.IngressInfo{
+			IngressId: "in_test",
+			State:     &livekit.IngressState{ResourceId: "res_test"},
+		},
+		TmpDir: tmpDir,
+	}
+}
+
+// requireNoResidue asserts the all-or-nothing property of startIngress: a
+// failed start must leave no temp directory, no active handler, and no RPC
+// topics on the bus.
+func requireNoResidue(t *testing.T, pm *ProcessManager, bus psrpc.MessageBus, tmpDir string) {
+	t.Helper()
+
+	// not os.IsNotExist: stat fails with ENOTDIR rather than ENOENT when a
+	// path component is not a directory
+	_, err := os.Stat(tmpDir)
+	require.Error(t, err, "temp directory should not exist")
+
+	pm.mu.RLock()
+	require.Empty(t, pm.activeHandlers)
+	pm.mu.RUnlock()
+
+	client, err := rpc.NewIngressHandlerClient(bus)
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	_, err = client.DeleteIngress(ctx, "in_test", &livekit.DeleteIngressRequest{},
+		psrpc.WithRequestTimeout(300*time.Millisecond))
+	require.Error(t, err)
+	require.True(t,
+		errors.Is(err, psrpc.ErrRequestTimedOut) || errors.Is(err, psrpc.ErrNoResponse),
+		"expected no server for the topic, got: %v", err)
+}
+
+func TestStartIngressRollsBackOnServiceSocketFailure(t *testing.T) {
+	pm, bus := newTestProcessManager(t)
+	tmpDir := filepath.Join(testutil.ShortTempDir(t), "session")
+
+	// occupy the service socket path with a non-empty directory so the
+	// pre-listen cleanup fails and the socket bind returns an error
+	require.NoError(t, os.MkdirAll(filepath.Join(tmpDir, "service_ipc.sock", "x"), 0755))
+
+	err := pm.startIngress(context.Background(), newTestParams(tmpDir), nil)
+	require.Error(t, err)
+
+	requireNoResidue(t, pm, bus, tmpDir)
+}
+
+func TestStartIngressFailsCleanlyWhenTmpDirCannotBeCreated(t *testing.T) {
+	pm, bus := newTestProcessManager(t)
+
+	// a regular file where the temp directory's parent should be makes
+	// MkdirAll fail
+	parent := filepath.Join(testutil.ShortTempDir(t), "file")
+	require.NoError(t, os.WriteFile(parent, []byte("x"), 0o644))
+	tmpDir := filepath.Join(parent, "session")
+
+	err := pm.startIngress(context.Background(), newTestParams(tmpDir), nil)
+	require.Error(t, err)
+
+	requireNoResidue(t, pm, bus, tmpDir)
+}

--- a/pkg/testutil/testutil.go
+++ b/pkg/testutil/testutil.go
@@ -1,0 +1,34 @@
+// Copyright 2026 LiveKit, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package testutil holds helpers for tests only; it must not be imported
+// from production code.
+package testutil
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// ShortTempDir returns a directory under /tmp for tests that create unix
+// sockets: t.TempDir() paths exceed the socket path limit (104 bytes on
+// darwin).
+func ShortTempDir(t *testing.T) string {
+	tmpDir, err := os.MkdirTemp("/tmp", "ingress-test")
+	require.NoError(t, err)
+	t.Cleanup(func() { os.RemoveAll(tmpDir) })
+	return tmpDir
+}


### PR DESCRIPTION
## Why

`startIngress` registers the per-session RPC topics (`UpdateIngress`, `DeleteIngress`, `DeleteWHIPResource`) **before** the handler's IPC client exists — the client is created later, in the `runHandler` goroutine. A request landing in that window resolves the topic, hits the nil client, and returns a false `ErrIngressNotFound` for an ingress that is actively starting. For a delete, "not found" naturally reads as already-gone, so the session keeps booting as an orphan. Realistic triggers: create-then-immediately-delete automation, or a WHIP client that connects and instantly drops.

Two related weaknesses in the same code:

- If `StartServiceServer` failed inside the `runHandler` goroutine, it returned **before** the cleanup defer was installed — leaking the registered topics, the active-handler entry, and the session-manager registration permanently, while the caller had already been told the start succeeded.
- Between crash-retry relaunches, the stored IPC client pointer briefly held a *closed* client.

## What

- `startIngress` now creates all IPC endpoints (service server + handler client) **before** registering the RPC topics, so an advertised topic can always resolve a client. Setup is strictly fallible-first, visible-last: every failure path unwinds completely (topics — including partial registration, client, server, temp dir), so a failed start returns an error to the caller and leaves zero residue. The previously ignored `RegisterIngressRpcHandlers` error is now checked.
- The `KillIngress` forwards use `grpc.WaitForReady(true)`: a delete arriving while the handler is still booting parks (bounded by the caller's request deadline) and then executes, instead of failing fast. Stats/debug forwards stay fail-fast.
- The handler client is created once per session instead of once per retry; gRPC re-dials the recreated socket across relaunches, which also removes the closed-client gap. The per-try client's hidden side effect — unlinking the stale socket so a relaunched handler can bind — moves to where it belongs: `StartHandlerServer` removes the stale socket before listening, mirroring `StartServiceServer`.

## Testing

- `TestStartHandlerServerRebindsExistingSocket` — red without the `conn.go` change, green with it (verified both ways).
- `TestStartIngressRollsBackOnServiceSocketFailure` / `TestStartIngressFailsCleanlyWhenTmpDirCannotBeCreated` — assert the all-or-nothing property three ways: temp dir removed, no active-handler entry, and a real psrpc `DeleteIngress` probe on an in-memory bus finding no server for the topic.
- New `pkg/testutil.ShortTempDir`: socket tests can't use `t.TempDir()` (unix socket paths are capped at 104 bytes on darwin).

Not covered: forcing a *partial* topic-registration failure isn't possible from outside psrpc (`MessageBus` is defined over internal types), so that rollback branch is exercised only by the deregister-all being idempotent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)