### PR TITLE
Align docker release workflow with the .go-version/Dockerfile scheme

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -26,7 +26,6 @@ permissions:
   contents: read
 
 env:
-  GOVERSION: "1.25.0"
   GSTVERSION: "1.26.7"
 
 jobs:
@@ -34,16 +33,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
-
-      - uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
-        with:
-          path: |
-            ~/go/pkg/mod
-            ~/go/bin
-            ~/bin/protoc
-            ~/.cache
-          key: ${{ runner.os }}-ingress-${{ hashFiles('**/go.sum') }}
-          restore-keys: ${{ runner.os }}-ingress
 
       - name: Docker metadata
         id: docker-md
@@ -54,14 +43,6 @@ jobs:
           tags: |
             type=semver,pattern=v{{version}}
             type=semver,pattern=v{{major}}.{{minor}}
-
-      - name: Set up Go
-        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7
-        with:
-          go-version: "1.25"
-
-      - name: Download Go modules
-        run: go mod download
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4
@@ -85,5 +66,5 @@ jobs:
           tags: ${{ steps.docker-md.outputs.tags }}
           labels: ${{ steps.docker-md.outputs.labels }}
           build-args: |
-            GOVERSION=${{ env.GOVERSION }}
             GSTVERSION=${{ env.GSTVERSION }}
+            SECURITY_REFRESH=${{ github.run_id }}-${{ github.run_attempt }}


### PR DESCRIPTION
`docker.yaml` still carried a Go toolchain pin and build plumbing from before the build moved to `.go-version` (#451).

- **Drop `GOVERSION`.** `build/ingress/Dockerfile` no longer declares that ARG — it reads `.go-version` and sets `GOTOOLCHAIN=local` — so the build-arg was silently ignored, and its `1.25.0` had already drifted from `.go-version`'s `1.26.5`.
- **Pass `SECURITY_REFRESH`**, matching `build.yaml` and `test.yaml`. Without it the `apt-get dist-upgrade` layers stay cached, so released images could ship without the security upgrades CI images get. This is the only change here with a runtime effect on published images.
- **Remove the Go setup, module cache, and `go mod download` steps.** Modules are downloaded inside the buildx build, which never saw the runner's `GOMODCACHE`, so these steps did no work and only added a second place to pin Go.

The workflow no longer references a Go version at all, so `.go-version` is the single Renovate-managed lever for the release toolchain. Job is now checkout → metadata → QEMU → Buildx → login → build-and-push, mirroring `build.yaml`.

## Testing

YAML parses and the step list is as expected. The build-and-push path only runs on `v*.*.*` tags; `build.yaml` builds the same Dockerfile on PRs and covers the `SECURITY_REFRESH` arg.

🤖 Generated with [Claude Code](https://claude.com/claude-code)