### PR TITLE
Enable psrpc claim-skip on queue rpcs behind config

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/livekit/media-sdk v0.0.0-20260812193843-5a5218b19550
 	github.com/livekit/mediatransportutil v0.0.0-20260727210231-81a5287a7109
 	github.com/livekit/protocol v1.50.4
-	github.com/livekit/psrpc v0.7.4
+	github.com/livekit/psrpc v0.7.5
 	github.com/livekit/server-sdk-go/v2 v2.18.1
 	github.com/pion/dtls/v3 v3.1.5
 	github.com/pion/interceptor v0.1.47

--- a/go.sum
+++ b/go.sum
@@ -113,8 +113,8 @@ github.com/livekit/mediatransportutil v0.0.0-20260727210231-81a5287a7109 h1:jLE+
 github.com/livekit/mediatransportutil v0.0.0-20260727210231-81a5287a7109/go.mod h1:o8CFmAdrVwzJNOCsQCLUzXRjokkufNshnQHOe4fRaqU=
 github.com/livekit/protocol v1.50.4 h1:Pzg9p1lpu9TcxUFJqIlUGNP6m7mX8PBT+ETxXRpnmZ8=
 github.com/livekit/protocol v1.50.4/go.mod h1:jO+y05AU9Ec4JswDyuzKCZ4bhziOS0CzMqgnbj60Dzs=
-github.com/livekit/psrpc v0.7.4 h1:4iW7V2pV1Kt0g06bgeGRiUYKzpcM40eotRGmuA5WxNk=
-github.com/livekit/psrpc v0.7.4/go.mod h1:rAI+m2+/cb4x9RXhLRtUx5ZwdfjjXOl4zi46IjEetaw=
+github.com/livekit/psrpc v0.7.5 h1:WxfJIQ41X1b+48A1uzc8Gy9FhYEMxBJNCpCYqPdO/Ds=
+github.com/livekit/psrpc v0.7.5/go.mod h1:rAI+m2+/cb4x9RXhLRtUx5ZwdfjjXOl4zi46IjEetaw=
 github.com/livekit/server-sdk-go/v2 v2.18.1 h1:/u0JVII+ErGCivHnAGr6di0wl0NYsfcRvDzEtTAFovo=
 github.com/livekit/server-sdk-go/v2 v2.18.1/go.mod h1:su0IvJNWTFCHVwmqpsFvxHfXWs9pn26ms+cKBR1jILU=
 github.com/mackerelio/go-osstat v0.2.7 h1:TCavZi10wF49bT6iQZ9eT2keGZQpC69MTDfdJej5e94=

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -59,7 +59,8 @@ type ServiceConfig struct {
 	HTTPRelayPort    int           `yaml:"http_relay_port"`
 	Logging          logger.Config `yaml:"logging"`
 	Development      bool          `yaml:"development"`
-	WHIPProxyEnabled bool          `yaml:"whip_proxy_enabled"` // If true, WHIP requests with transcoding bypassed will be handled by the SFU directly
+	WHIPProxyEnabled bool          `yaml:"whip_proxy_enabled"`         // If true, WHIP requests with transcoding bypassed will be handled by the SFU directly
+	PSRPCSkipClaim   bool          `yaml:"psrpc_skip_claim,omitempty"` // Lets psrpc servers skip the claim handshake on queue rpcs
 
 	// Used for WHIP transport
 	RTCConfig rtcconfig.RTCConfig `yaml:"rtc_config"`
@@ -109,6 +110,12 @@ func NewConfig(confString string) (*Config, error) {
 
 	return conf, nil
 }
+
+// SkipClaimEnabled gates psrpc.WithServerSkipClaim on the ingress rpc servers.
+func (c *ServiceConfig) SkipClaimEnabled() bool {
+	return c.PSRPCSkipClaim
+}
+
 func (c *ServiceConfig) InitDefaults() error {
 	if c.RTMPPort == 0 {
 		c.RTMPPort = DefaultRTMPPort

--- a/pkg/service/process_manager.go
+++ b/pkg/service/process_manager.go
@@ -146,7 +146,7 @@ func (s *ProcessManager) startIngress(ctx context.Context, p *params.Params, clo
 	h.ipcHandlerClient = ipcHandlerClient
 	h.grpcClient.Store(&ipcHandlerClient.IngressHandlerClient)
 
-	rpcServer, err := rpc.NewIngressHandlerServer(h, s.bus)
+	rpcServer, err := rpc.NewIngressHandlerServer(h, s.bus, psrpc.WithServerSkipClaim(p.SkipClaimEnabled))
 	if err != nil {
 		ipcHandlerClient.Close()
 		ipcServiceServer.Stop()

--- a/pkg/whip/whip_handler.go
+++ b/pkg/whip/whip_handler.go
@@ -115,7 +115,7 @@ func newWHIPHandler(p *params.Params, webRTCConfig *rtcconfig.WebRTCConfig, bus 
 
 	var err error
 	if bus != nil {
-		h.rpcServer, err = rpc.NewIngressHandlerServer(h, bus)
+		h.rpcServer, err = rpc.NewIngressHandlerServer(h, bus, psrpc.WithServerSkipClaim(p.SkipClaimEnabled))
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/whip/whip_proxy_handler.go
+++ b/pkg/whip/whip_proxy_handler.go
@@ -66,7 +66,7 @@ func NewProxyWHIPHandler(p *params.Params, bus psrpc.MessageBus, ua string) (WHI
 		ua:     ua,
 	}
 
-	rpcServer, err := rpc.NewIngressHandlerServer(h, bus)
+	rpcServer, err := rpc.NewIngressHandlerServer(h, bus, psrpc.WithServerSkipClaim(p.SkipClaimEnabled))
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## What

[psrpc v0.7.5](https://github.com/livekit/psrpc/pull/122) lets a server answer an advertised queue rpc with an announcement instead of the claim round trip, removing one bus round trip per call. Clients on v0.7.5+ advertise support automatically; the server elects per request via `psrpc.WithServerSkipClaim(func() bool)`.

This PR:
- bumps `psrpc` v0.7.4 → v0.7.5
- adds `psrpc_skip_claim` (bool, **default off**) to `ServiceConfig`, read once at startup — ingress has no live config reload, so flipping it requires a restart
- passes `psrpc.WithServerSkipClaim` to the `IngressHandler` server constructions

## Server coverage

| Server | Site | Claim+queue methods | Wired |
|---|---|---|---|
| IngressHandler | `pkg/service/process_manager.go` | UpdateIngress, DeleteIngress, DeleteWHIPResource, ICERestartWHIPResource | yes |
| IngressHandler | `pkg/whip/whip_handler.go` | same | yes |
| IngressHandler | `pkg/whip/whip_proxy_handler.go` | same | yes |
| IngressInternal | `pkg/service/service.go` | none (StartIngress is claim-only/non-queue, ListActiveIngress is multi) | no — nothing to skip |

## Client side

The bump alone makes ingress's psrpc clients advertise skip support, so the per-session IOInfo calls (`GetIngressInfo`, `UpdateIngressState`) skip the claim once the IO server enables it — no config needed here for that.

## Dependency note

[livekit/protocol#1729](https://github.com/livekit/protocol/pull/1729) added a process-wide `rpc.SetPSRPCServerSkipClaim` gate, but it only reaches servers built with the protocol's server-option helpers, which ingress doesn't use — and bumping protocol past v1.50.4 currently breaks the build against `server-sdk-go` v2.18.1 (`TransferSIPParticipant` signature change). So this PR stays on protocol v1.50.4 and passes `psrpc.WithServerSkipClaim` directly at the construction sites, which is equivalent.

## Verified

- `go build ./...` clean (macOS, GStreamer 1.28 via Homebrew)
- `go test -race` on all non-integration packages: pass
- Integration tests (`//go:build integration`) deferred to CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)