### PR TITLE
Fix panic and hang when a kill races pipeline startup

### DIFF
--- a/pkg/media/pipeline.go
+++ b/pkg/media/pipeline.go
@@ -89,9 +89,12 @@ func New(ctx context.Context, params *params.Params, g *stats.LocalMediaStatsGat
 	}
 
 	p := &Pipeline{
-		Params:      params,
-		pipeline:    pipeline,
-		input:       input,
+		Params:   params,
+		pipeline: pipeline,
+		input:    input,
+		// SendEOS can reach the loop before Run does, so it is built here
+		// rather than on the way into the loop, and is never nil.
+		loop:        glib.NewMainLoop(glib.MainContextDefault(), false),
 		pipelineErr: make(chan error, 1),
 		eos:         newEOSDispatcher(),
 		established: make(map[types.StreamKind]string),
@@ -104,9 +107,7 @@ func New(ctx context.Context, params *params.Params, g *stats.LocalMediaStatsGat
 			(*cancel)()
 		}
 
-		if p.loop != nil {
-			p.loop.Quit()
-		}
+		p.quitLoop()
 	}, g, p.eos)
 	if err != nil {
 		return nil, err
@@ -213,7 +214,6 @@ func (p *Pipeline) Run(ctx context.Context) error {
 	var err error
 
 	// add watch
-	p.loop = glib.NewMainLoop(glib.MainContextDefault(), false)
 	p.pipeline.GetPipelineBus().AddWatch(p.messageWatch)
 
 	// set state to playing (this does not start the pipeline)
@@ -237,6 +237,9 @@ func (p *Pipeline) Run(ctx context.Context) error {
 	logger.Infow("starting GST pipeline")
 
 	// run main loop
+	if p.closed.IsBroken() {
+		logger.Warnw("shutdown requested before the main loop started, queued until the loop starts", nil)
+	}
 	p.loop.Run()
 
 	logger.Infow("GST pipeline stopped")
@@ -382,9 +385,21 @@ func (p *Pipeline) SendEOS(ctx context.Context) {
 				logger.Errorw("pipeline frozen", psrpc.NewErrorf(psrpc.Internal, "pipeline frozen"))
 			}
 
-			p.loop.Quit()
+			p.quitLoop()
 		}()
 	})
+}
+
+// quitLoop stops the main loop, and is safe to call before Run has started it:
+// the quit is queued on the main context and dispatched when the loop runs.
+// Calling Quit directly is not safe there, because g_main_loop_run sets
+// is_running=TRUE on entry and overwrites it. Assumes this is the only main
+// loop on the default context.
+func (p *Pipeline) quitLoop() {
+	if _, err := glib.IdleAdd(p.loop.Quit); err != nil {
+		logger.Errorw("failed to schedule loop quit, quitting directly", err)
+		p.loop.Quit()
+	}
 }
 
 func (p *Pipeline) GetGstPipelineDebugDot() string {

--- a/pkg/media/pipeline.go
+++ b/pkg/media/pipeline.go
@@ -211,6 +211,14 @@ func (p *Pipeline) Run(ctx context.Context) error {
 
 	p.cancel.Store(&cancel)
 
+	// Shutdown already requested: bail out before starting anything. Only the
+	// sink needs closing; New brought it up, while the input has not started
+	// and closing an unstarted one blocks.
+	if p.closed.IsBroken() {
+		logger.Infow("shutdown requested before the pipeline started")
+		return p.sink.Close()
+	}
+
 	var err error
 
 	// add watch
@@ -237,9 +245,6 @@ func (p *Pipeline) Run(ctx context.Context) error {
 	logger.Infow("starting GST pipeline")
 
 	// run main loop
-	if p.closed.IsBroken() {
-		logger.Warnw("shutdown requested before the main loop started, queued until the loop starts", nil)
-	}
 	p.loop.Run()
 
 	logger.Infow("GST pipeline stopped")
@@ -355,39 +360,44 @@ func (p *Pipeline) SendEOS(ctx context.Context) {
 	_, span := tracer.Start(ctx, "Pipeline.SendEOS")
 	defer span.End()
 
-	p.closed.Once(func() {
-		logger.Debugw("closing pipeline")
+	// Break before loading the cancel below. Run stores its cancel and then
+	// checks the fuse, so this order leaves no interleaving where Run both
+	// misses the check and has not yet stored a cancel for this to find.
+	if !p.closed.Break() {
+		return
+	}
 
-		if cancel := p.cancel.Load(); cancel != nil {
-			(*cancel)()
+	logger.Debugw("closing pipeline")
+
+	if cancel := p.cancel.Load(); cancel != nil {
+		(*cancel)()
+	}
+
+	c := make(chan struct{})
+
+	go func() {
+		err := p.pipeline.BlockSetState(gst.StateNull)
+		if err != nil {
+			logger.Errorw("failed stopping pipeline", err)
 		}
 
-		c := make(chan struct{})
+		close(c)
+	}()
 
-		go func() {
-			err := p.pipeline.BlockSetState(gst.StateNull)
-			if err != nil {
-				logger.Errorw("failed stopping pipeline", err)
-			}
+	go func() {
+		t := time.NewTimer(5 * time.Second)
 
-			close(c)
-		}()
+		select {
+		case <-c:
+			t.Stop()
+		case <-t.C:
+			// Do not set ingress in error state as we are stopping and this causes some media at the end
+			// to not be sent to the room at worse
+			logger.Errorw("pipeline frozen", psrpc.NewErrorf(psrpc.Internal, "pipeline frozen"))
+		}
 
-		go func() {
-			t := time.NewTimer(5 * time.Second)
-
-			select {
-			case <-c:
-				t.Stop()
-			case <-t.C:
-				// Do not set ingress in error state as we are stopping and this causes some media at the end
-				// to not be sent to the room at worse
-				logger.Errorw("pipeline frozen", psrpc.NewErrorf(psrpc.Internal, "pipeline frozen"))
-			}
-
-			p.quitLoop()
-		}()
-	})
+		p.quitLoop()
+	}()
 }
 
 // quitLoop stops the main loop, and is safe to call before Run has started it:

--- a/pkg/media/pipeline_test.go
+++ b/pkg/media/pipeline_test.go
@@ -15,12 +15,19 @@
 package media
 
 import (
+	"context"
+	"os"
+	"os/exec"
+	"sync"
 	"testing"
+	"time"
 
+	"github.com/go-gst/go-glib/glib"
 	"github.com/go-gst/go-gst/gst"
 	"github.com/stretchr/testify/require"
 
 	"github.com/livekit/ingress/pkg/types"
+	"github.com/livekit/protocol/logger"
 )
 
 const testSystemMemoryCaps = "video/x-raw,format=NV12,width=1280,height=720,framerate=30/1"
@@ -75,4 +82,275 @@ func TestCapsNotificationWithoutCapsIsIgnored(t *testing.T) {
 	p.onParamsReady(types.Video, gst.NewGhostPadNoTarget("video", gst.PadDirectionSource))
 
 	require.Empty(t, p.established)
+}
+
+// CS-1376. Handler.HandleIngress starts Run on a goroutine and calls SendEOS
+// from its kill watcher, so a DeleteIngress arriving during startup runs both
+// against the same Pipeline. Two failures came out of that:
+//
+//   - Run used to create p.loop, so SendEOS could dereference a nil loop and
+//     take the handler process down with it.
+//   - Even once the loop existed, a direct Quit issued before Run reached
+//     loop.Run() was discarded, and the handler hung on a loop nobody would
+//     stop again. That one is silent, which makes it the worse of the two.
+//
+// New now builds the loop, and quitLoop queues the quit as an idle source so it
+// survives until the loop starts.
+
+const eosChildEnv = "INGRESS_EOS_RACE_CHILD"
+
+// The warning Run emits when the shutdown beat it to the loop.
+const raceWarning = "shutdown requested before the main loop started"
+
+// newTestPipeline is the state New leaves a Pipeline in, minus the parts that
+// need a room connection. The loop matters here: it is what New now owns.
+func newTestPipeline(t *testing.T) *Pipeline {
+	t.Helper()
+
+	gst.Init(nil)
+
+	pipeline, err := gst.NewPipeline("pipeline")
+	require.NoError(t, err)
+
+	return &Pipeline{
+		pipeline:    pipeline,
+		loop:        glib.NewMainLoop(glib.MainContextDefault(), false),
+		pipelineErr: make(chan error, 1),
+		eos:         newEOSDispatcher(),
+	}
+}
+
+// startLoop starts the loop and returns a channel closed once it stops. The
+// channel is returned rather than waited on here so that a test can observe the
+// same run twice: a loop that is already running must not be started again.
+func startLoop(p *Pipeline) <-chan struct{} {
+	returned := make(chan struct{})
+	go func() {
+		p.loop.Run()
+		close(returned)
+	}()
+
+	return returned
+}
+
+func stoppedWithin(returned <-chan struct{}, timeout time.Duration) bool {
+	select {
+	case <-returned:
+		return true
+	case <-time.After(timeout):
+		return false
+	}
+}
+
+// runLoop starts the loop and reports whether it stopped within the timeout.
+func runLoop(p *Pipeline, timeout time.Duration) bool {
+	return stoppedWithin(startLoop(p), timeout)
+}
+
+// waitRunning blocks until the loop is running, and gives up rather than
+// spinning forever so a pipeline that never starts one fails instead of hanging.
+func waitRunning(t *testing.T, l *glib.MainLoop) {
+	t.Helper()
+
+	deadline := time.Now().Add(5 * time.Second)
+	for !l.IsRunning() {
+		if time.Now().After(deadline) {
+			t.Fatal("loop never started")
+		}
+		time.Sleep(time.Millisecond)
+	}
+}
+
+// stubSource is the smallest Source that lets Run reach its main loop. The real
+// ones all want a network peer.
+type stubSource struct{}
+
+func (stubSource) GetSources() []*gst.Element          { return nil }
+func (stubSource) ValidateCaps(*gst.Caps) error        { return nil }
+func (stubSource) Start(context.Context, func()) error { return nil }
+func (stubSource) Close() error                        { return nil }
+
+// runnableTestPipeline adds the two collaborators Run walks through, stubbed to
+// the minimum that lets it both reach and leave the loop.
+func runnableTestPipeline(t *testing.T) *Pipeline {
+	t.Helper()
+
+	p := newTestPipeline(t)
+	p.input = &Input{source: stubSource{}}
+
+	sink := &WebRTCSink{}
+	sink.sdkReady.Break() // Close blocks on this
+	p.sink = sink
+
+	return p
+}
+
+// The regression for both halves of the bug, on the real SendEOS path. Runs in
+// a child process because the nil dereference happened on a goroutine SendEOS
+// spawns, and no parent can recover a panic raised on another goroutine: before
+// the fix the process died outright rather than failing an assertion.
+func TestSendEOSBeforeRunIsHonored(t *testing.T) {
+	if os.Getenv(eosChildEnv) == "1" {
+		p := newTestPipeline(t)
+
+		// The race: EOS lands before Run has started the loop.
+		p.SendEOS(context.Background())
+
+		// SendEOS issues its quit from a goroutine, once the pipeline has gone
+		// to NULL. Wait for that to have happened before starting the loop, so
+		// the quit is reliably the early one this test is about; without the
+		// wait the loop is often already running by then and the race is not
+		// exercised at all. Going to NULL on an empty pipeline takes
+		// microseconds, so this is a wide margin, not a tuned one.
+		time.Sleep(500 * time.Millisecond)
+		require.False(t, p.loop.IsRunning(), "loop must not have started yet")
+
+		require.True(t, runLoop(p, 10*time.Second),
+			"loop.Run did not return: the queued EOS was lost")
+		return
+	}
+
+	out, err := runChild(t, "TestSendEOSBeforeRunIsHonored")
+
+	require.NoError(t, err, "child process failed:\n%s", out)
+	require.NotContains(t, string(out), "panic:", "child panicked:\n%s", out)
+}
+
+// The queuing on its own, without SendEOS's timers deciding when the quit is
+// issued. This pins the ordering the fix depends on: quit first, loop second.
+func TestQuitLoopBeforeRunIsHonored(t *testing.T) {
+	p := newTestPipeline(t)
+
+	p.quitLoop()
+
+	require.True(t, runLoop(p, 5*time.Second),
+		"a quit queued before Run must still stop the loop")
+}
+
+// quitLoop is also reached from the sink's close callback and from SendEOS's
+// timeout goroutine, so it has to tolerate being called more than once and from
+// several goroutines. Meaningful under -race.
+func TestQuitLoopIsSafeConcurrently(t *testing.T) {
+	p := newTestPipeline(t)
+
+	var wg sync.WaitGroup
+	for range 4 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			p.quitLoop()
+		}()
+	}
+	wg.Wait()
+
+	require.True(t, runLoop(p, 5*time.Second), "loop must still stop")
+}
+
+// SendEOS is fused, but the fuse only stops the body running twice; it does not
+// order SendEOS against Run. Guards that the fused path still stops the loop.
+func TestSendEOSTwiceStillStopsTheLoop(t *testing.T) {
+	p := newTestPipeline(t)
+
+	p.SendEOS(context.Background())
+	p.SendEOS(context.Background())
+
+	require.True(t, runLoop(p, 10*time.Second), "loop must still stop")
+}
+
+// Run itself, on the racing path: the shutdown lands first, and Run has to
+// reach the loop, be stopped by the queued quit, and report the race. Driving
+// the real Run is what makes this a regression test for the loop moving back
+// out of New, which the tests above cannot see. Child process, because the
+// assertion is on log output and the default logger discards.
+func TestRunReportsAndSurvivesTheStartupRace(t *testing.T) {
+	if os.Getenv(eosChildEnv) == "1" {
+		logger.InitFromConfig(&logger.Config{Level: "debug"}, "ingress")
+
+		p := runnableTestPipeline(t)
+
+		p.SendEOS(context.Background())
+		time.Sleep(500 * time.Millisecond)
+		require.False(t, p.loop.IsRunning(), "loop must not have started yet")
+
+		done := make(chan error, 1)
+		go func() { done <- p.Run(context.Background()) }()
+
+		select {
+		case err := <-done:
+			require.NoError(t, err)
+		case <-time.After(10 * time.Second):
+			t.Fatal("Run did not return: the queued quit never reached its loop")
+		}
+		return
+	}
+
+	out, err := runChild(t, "TestRunReportsAndSurvivesTheStartupRace")
+
+	require.NoError(t, err, "child process failed:\n%s", out)
+	require.Contains(t, string(out), raceWarning,
+		"the startup race should be reported:\n%s", out)
+}
+
+// The warning has to be specific to the race or it is noise: a shutdown that
+// arrives once Run is already in the loop is ordinary, and must stay quiet.
+func TestRunIsQuietWhenShutdownArrivesLater(t *testing.T) {
+	if os.Getenv(eosChildEnv) == "1" {
+		logger.InitFromConfig(&logger.Config{Level: "debug"}, "ingress")
+
+		p := runnableTestPipeline(t)
+
+		done := make(chan error, 1)
+		go func() { done <- p.Run(context.Background()) }()
+
+		waitRunning(t, p.loop)
+		p.SendEOS(context.Background())
+
+		select {
+		case err := <-done:
+			require.NoError(t, err)
+		case <-time.After(10 * time.Second):
+			t.Fatal("Run did not return")
+		}
+		return
+	}
+
+	out, err := runChild(t, "TestRunIsQuietWhenShutdownArrivesLater")
+
+	require.NoError(t, err, "child process failed:\n%s", out)
+	require.NotContains(t, string(out), raceWarning,
+		"a shutdown after the loop started is not the race:\n%s", out)
+}
+
+// Why quitLoop queues rather than calling Quit directly. g_main_loop_run sets
+// is_running itself, so a direct Quit arriving first is overwritten and lost:
+// the flag records "not running", never "was asked to stop". This is GStreamer
+// behavior rather than ours, so it is pinned here to justify the indirection
+// and to catch it changing under us.
+func TestDirectQuitBeforeRunIsLost(t *testing.T) {
+	p := newTestPipeline(t)
+
+	p.loop.Quit()
+
+	returned := startLoop(p)
+
+	require.False(t, stoppedWithin(returned, 2*time.Second),
+		"a direct quit before Run is expected to be lost; if this now passes, "+
+			"quitLoop's idle source may no longer be needed")
+
+	// Confirms the loop really is running, rather than merely unscheduled.
+	require.True(t, p.loop.IsRunning())
+
+	// Stop the run started above; do not start a second one.
+	p.loop.Quit()
+	require.True(t, stoppedWithin(returned, 5*time.Second),
+		"loop did not stop on the second quit")
+}
+
+func runChild(t *testing.T, testName string) ([]byte, error) {
+	t.Helper()
+
+	cmd := exec.Command(os.Args[0], "-test.run=^"+testName+"$", "-test.v")
+	cmd.Env = append(os.Environ(), eosChildEnv+"=1")
+
+	return cmd.CombinedOutput()
 }

--- a/pkg/media/pipeline_test.go
+++ b/pkg/media/pipeline_test.go
@@ -19,6 +19,7 @@ import (
 	"os"
 	"os/exec"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -27,7 +28,6 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/livekit/ingress/pkg/types"
-	"github.com/livekit/protocol/logger"
 )
 
 const testSystemMemoryCaps = "video/x-raw,format=NV12,width=1280,height=720,framerate=30/1"
@@ -84,26 +84,17 @@ func TestCapsNotificationWithoutCapsIsIgnored(t *testing.T) {
 	require.Empty(t, p.established)
 }
 
-// CS-1376. Handler.HandleIngress starts Run on a goroutine and calls SendEOS
-// from its kill watcher, so a DeleteIngress arriving during startup runs both
-// against the same Pipeline. Two failures came out of that:
-//
-//   - Run used to create p.loop, so SendEOS could dereference a nil loop and
-//     take the handler process down with it.
-//   - Even once the loop existed, a direct Quit issued before Run reached
-//     loop.Run() was discarded, and the handler hung on a loop nobody would
-//     stop again. That one is silent, which makes it the worse of the two.
-//
-// New now builds the loop, and quitLoop queues the quit as an idle source so it
-// survives until the loop starts.
+// Pipeline shutdown races its own startup: Handler.HandleIngress starts Run on
+// a goroutine and calls SendEOS from its kill watcher, so a kill arriving during
+// startup drives both against one Pipeline. The tests below cover a shutdown
+// that reaches the pipeline before Run does. It must not find a nil loop, must
+// stop Run before it starts anything, and its quit must survive until the loop
+// runs.
 
 const eosChildEnv = "INGRESS_EOS_RACE_CHILD"
 
-// The warning Run emits when the shutdown beat it to the loop.
-const raceWarning = "shutdown requested before the main loop started"
-
-// newTestPipeline is the state New leaves a Pipeline in, minus the parts that
-// need a room connection. The loop matters here: it is what New now owns.
+// newTestPipeline builds the parts of a Pipeline these tests exercise, minus
+// the ones that need a room connection.
 func newTestPipeline(t *testing.T) *Pipeline {
 	t.Helper()
 
@@ -161,34 +152,52 @@ func waitRunning(t *testing.T, l *glib.MainLoop) {
 	}
 }
 
-// stubSource is the smallest Source that lets Run reach its main loop. The real
-// ones all want a network peer.
-type stubSource struct{}
+// stubSource is the smallest Source that lets Run reach its main loop; the real
+// ones all want a network peer. Start records that it ran and, when block is
+// set, waits there, which is how a test holds Run inside startup.
+type stubSource struct {
+	started atomic.Bool
+	entered chan struct{}
+	block   chan struct{}
+}
 
-func (stubSource) GetSources() []*gst.Element          { return nil }
-func (stubSource) ValidateCaps(*gst.Caps) error        { return nil }
-func (stubSource) Start(context.Context, func()) error { return nil }
-func (stubSource) Close() error                        { return nil }
+func (s *stubSource) GetSources() []*gst.Element   { return nil }
+func (s *stubSource) ValidateCaps(*gst.Caps) error { return nil }
+func (s *stubSource) Close() error                 { return nil }
+
+func (s *stubSource) Start(context.Context, func()) error {
+	s.started.Store(true)
+	if s.entered != nil {
+		close(s.entered)
+	}
+	if s.block != nil {
+		<-s.block
+	}
+
+	return nil
+}
 
 // runnableTestPipeline adds the two collaborators Run walks through, stubbed to
 // the minimum that lets it both reach and leave the loop.
-func runnableTestPipeline(t *testing.T) *Pipeline {
+func runnableTestPipeline(t *testing.T) (*Pipeline, *stubSource) {
 	t.Helper()
 
 	p := newTestPipeline(t)
-	p.input = &Input{source: stubSource{}}
+
+	src := &stubSource{}
+	p.input = &Input{source: src}
 
 	sink := &WebRTCSink{}
 	sink.sdkReady.Break() // Close blocks on this
 	p.sink = sink
 
-	return p
+	return p, src
 }
 
-// The regression for both halves of the bug, on the real SendEOS path. Runs in
-// a child process because the nil dereference happened on a goroutine SendEOS
-// spawns, and no parent can recover a panic raised on another goroutine: before
-// the fix the process died outright rather than failing an assertion.
+// A shutdown landing before Run must still leave the loop stoppable. Runs in a
+// child process: SendEOS quits from a goroutine it spawns, and a panic there
+// cannot be recovered by the test, so it has to be observed as a dead process
+// rather than a failed assertion.
 func TestSendEOSBeforeRunIsHonored(t *testing.T) {
 	if os.Getenv(eosChildEnv) == "1" {
 		p := newTestPipeline(t)
@@ -196,13 +205,14 @@ func TestSendEOSBeforeRunIsHonored(t *testing.T) {
 		// The race: EOS lands before Run has started the loop.
 		p.SendEOS(context.Background())
 
-		// SendEOS issues its quit from a goroutine, once the pipeline has gone
-		// to NULL. Wait for that to have happened before starting the loop, so
-		// the quit is reliably the early one this test is about; without the
-		// wait the loop is often already running by then and the race is not
-		// exercised at all. Going to NULL on an empty pipeline takes
-		// microseconds, so this is a wide margin, not a tuned one.
-		time.Sleep(500 * time.Millisecond)
+		// SendEOS queues its quit from a goroutine, once the pipeline has gone
+		// to NULL. Wait until the source is actually on the context, so this
+		// exercises a quit that precedes Run rather than one that happens to
+		// land while the loop is already running. A sleep would not tell the
+		// two apart. The child runs this test alone, so nothing else has left
+		// sources on the default context.
+		require.Eventually(t, glib.MainContextDefault().Pending,
+			5*time.Second, 5*time.Millisecond, "the quit was never queued")
 		require.False(t, p.loop.IsRunning(), "loop must not have started yet")
 
 		require.True(t, runLoop(p, 10*time.Second),
@@ -246,79 +256,80 @@ func TestQuitLoopIsSafeConcurrently(t *testing.T) {
 	require.True(t, runLoop(p, 5*time.Second), "loop must still stop")
 }
 
-// SendEOS is fused, but the fuse only stops the body running twice; it does not
-// order SendEOS against Run. Guards that the fused path still stops the loop.
-func TestSendEOSTwiceStillStopsTheLoop(t *testing.T) {
-	p := newTestPipeline(t)
+// A shutdown that lands before Run must stop it before it starts anything.
+// Starting the input would be unrecoverable: the real sources block on a
+// network peer, and Run would sit there with the shutdown already spent.
+func TestRunBailsWhenShutdownArrivedFirst(t *testing.T) {
+	p, src := runnableTestPipeline(t)
 
 	p.SendEOS(context.Background())
+
+	done := make(chan error, 1)
+	go func() { done <- p.Run(context.Background()) }()
+
+	select {
+	case err := <-done:
+		require.NoError(t, err)
+	case <-time.After(10 * time.Second):
+		t.Fatal("Run did not return: it started work a spent shutdown cannot undo")
+	}
+
+	require.False(t, src.started.Load(), "the input must not be started")
+	require.False(t, p.loop.IsRunning(), "the loop must not be started")
+}
+
+// The other window: the shutdown lands while Run is inside startup, past the
+// bail and short of the loop. Run has to reach the loop and be stopped by the
+// queued quit. Driving the real Run is what makes this a regression test for
+// the loop moving back out of New.
+func TestRunSurvivesTheStartupRace(t *testing.T) {
+	p, src := runnableTestPipeline(t)
+	src.entered = make(chan struct{})
+	src.block = make(chan struct{})
+
+	done := make(chan error, 1)
+	go func() { done <- p.Run(context.Background()) }()
+
+	// Hold Run inside input.Start, which is where the real sources block, and
+	// shut down from there.
+	<-src.entered
 	p.SendEOS(context.Background())
 
-	require.True(t, runLoop(p, 10*time.Second), "loop must still stop")
+	// SendEOS queues its quit from a goroutine. Wait until the source is on
+	// the context before releasing Run, so the quit is reliably the one that
+	// precedes the loop rather than one that lands while it is already
+	// running -- the case that always worked.
+	require.Eventually(t, glib.MainContextDefault().Pending,
+		5*time.Second, 5*time.Millisecond, "the quit was never queued")
+	require.False(t, p.loop.IsRunning(), "loop must not have started yet")
+
+	close(src.block)
+
+	select {
+	case err := <-done:
+		require.NoError(t, err)
+	case <-time.After(10 * time.Second):
+		t.Fatal("Run did not return: the queued quit never reached its loop")
+	}
 }
 
-// Run itself, on the racing path: the shutdown lands first, and Run has to
-// reach the loop, be stopped by the queued quit, and report the race. Driving
-// the real Run is what makes this a regression test for the loop moving back
-// out of New, which the tests above cannot see. Child process, because the
-// assertion is on log output and the default logger discards.
-func TestRunReportsAndSurvivesTheStartupRace(t *testing.T) {
-	if os.Getenv(eosChildEnv) == "1" {
-		logger.InitFromConfig(&logger.Config{Level: "debug"}, "ingress")
+// A shutdown arriving once Run is already in the loop is the ordinary case and
+// must still stop it.
+func TestRunStopsWhenShutdownArrivesLater(t *testing.T) {
+	p, _ := runnableTestPipeline(t)
 
-		p := runnableTestPipeline(t)
+	done := make(chan error, 1)
+	go func() { done <- p.Run(context.Background()) }()
 
-		p.SendEOS(context.Background())
-		time.Sleep(500 * time.Millisecond)
-		require.False(t, p.loop.IsRunning(), "loop must not have started yet")
+	waitRunning(t, p.loop)
+	p.SendEOS(context.Background())
 
-		done := make(chan error, 1)
-		go func() { done <- p.Run(context.Background()) }()
-
-		select {
-		case err := <-done:
-			require.NoError(t, err)
-		case <-time.After(10 * time.Second):
-			t.Fatal("Run did not return: the queued quit never reached its loop")
-		}
-		return
+	select {
+	case err := <-done:
+		require.NoError(t, err)
+	case <-time.After(10 * time.Second):
+		t.Fatal("Run did not return")
 	}
-
-	out, err := runChild(t, "TestRunReportsAndSurvivesTheStartupRace")
-
-	require.NoError(t, err, "child process failed:\n%s", out)
-	require.Contains(t, string(out), raceWarning,
-		"the startup race should be reported:\n%s", out)
-}
-
-// The warning has to be specific to the race or it is noise: a shutdown that
-// arrives once Run is already in the loop is ordinary, and must stay quiet.
-func TestRunIsQuietWhenShutdownArrivesLater(t *testing.T) {
-	if os.Getenv(eosChildEnv) == "1" {
-		logger.InitFromConfig(&logger.Config{Level: "debug"}, "ingress")
-
-		p := runnableTestPipeline(t)
-
-		done := make(chan error, 1)
-		go func() { done <- p.Run(context.Background()) }()
-
-		waitRunning(t, p.loop)
-		p.SendEOS(context.Background())
-
-		select {
-		case err := <-done:
-			require.NoError(t, err)
-		case <-time.After(10 * time.Second):
-			t.Fatal("Run did not return")
-		}
-		return
-	}
-
-	out, err := runChild(t, "TestRunIsQuietWhenShutdownArrivesLater")
-
-	require.NoError(t, err, "child process failed:\n%s", out)
-	require.NotContains(t, string(out), raceWarning,
-		"a shutdown after the loop started is not the race:\n%s", out)
 }
 
 // Why quitLoop queues rather than calling Quit directly. g_main_loop_run sets
@@ -334,8 +345,8 @@ func TestDirectQuitBeforeRunIsLost(t *testing.T) {
 	returned := startLoop(p)
 
 	require.False(t, stoppedWithin(returned, 2*time.Second),
-		"a direct quit before Run is expected to be lost; if this now passes, "+
-			"quitLoop's idle source may no longer be needed")
+		"a direct quit before Run is expected to be lost; if this passes, "+
+			"quitLoop's idle source may be unnecessary")
 
 	// Confirms the loop really is running, rather than merely unscheduled.
 	require.True(t, p.loop.IsRunning())


### PR DESCRIPTION
`Handler.HandleIngress` starts `Pipeline.Run` on a goroutine and calls `SendEOS` from its kill watcher, so a kill arriving during startup drives both against one `Pipeline`. The kill fuse is level triggered, so it can already be broken before `Run` is even scheduled.

Three distinct failures live in that overlap. Each needs a different mechanism, which is why this is more than a one-line fix.

| Kill arrives | Failure on main | Handled by |
|---|---|---|
| Before `Run` stores its cancel | panic on a nil loop | the bail in `Run` — nothing is started |
| While blocked inside `input.Start` | quit overwritten, handler hangs | the stored cancel aborts the request |
| After `input.Start`, before the loop starts | quit overwritten, handler hangs | the queued quit, dispatched when the loop starts |
| While the loop runs | works | unchanged — `messageWatch` quits on its own thread |

### Why a quit could be lost

`g_main_loop_quit` has no running check — it unconditionally sets `is_running = FALSE`. `g_main_loop_run` then sets it `TRUE` on entry, unconditionally, and only afterwards reads it:

```c
g_atomic_int_set (&loop->is_running, TRUE);       /* gmain.c:4875 */
while (g_atomic_int_get (&loop->is_running))
  g_main_context_iterate_unlocked (loop->context, TRUE, TRUE, self);
```

So an early quit is not rejected, it is overwritten. `FALSE` is also the loop's initial value, so the flag cannot distinguish "not started yet" from "asked to stop" — the request was never representable. A source queued on the main context is not something `Run` can overwrite, and is dispatched as soon as the loop starts.

### Why the hang mattered more than the panic

The panic killed the handler process, which is one ingress, and the parent then cleaned up normally. The hang did not: nothing reaps a handler stuck in `loop.Run()`. The process manager only cleans up once `cmd.Run` returns, its SIGKILL backstop is guarded on a fuse already broken by then, and the handler traps the SIGINT that `killAll` sends. The process outlives its ingress, holds the room participant open, fails the `DeleteIngress`, and blocks the instance from draining — `for !s.sm.IsIdle()` never exits. It is also silent, and its window spans `pipeline.Start` and `input.Start`, so it is likely more common than the panic that was reported.

### The change

- **`New`** builds the main loop, so `p.loop` is never nil and is written once, before any goroutine exists. The nil dereference and the data race both go away structurally rather than by locking.
- **`quitLoop`** queues quits as a GLib idle source rather than issuing them. Used by `SendEOS` and the sink's close callback, which run on arbitrary goroutines. The two `Quit` calls in `messageWatch` are untouched: the loop dispatches that callback itself, so a direct quit there is always correct.
- **`Run`** stores its cancel, then bails if the fuse is already broken, closing the sink only. `New` brought the sink up, while the input has not started and `RTMPRelaySource.Close` receives on a channel `Start` creates, so closing an unstarted input blocks on a nil channel.
- **`SendEOS`** breaks the fuse before loading the cancel. `core.Fuse.Once` marks broken in a `defer` and closes its channel after the callback returns, so a cancel loaded inside `Once` was read while `IsBroken` still reported false. Without this order the bail and the cancel do not cover between them.

### Tests

Each mechanism was removed separately to confirm the suite notices. A test that cannot fail against a plausible bug is not worth having.

| Mechanism removed | Tests that fail |
|---|---|
| The queued quit — `quitLoop` quits directly | `TestSendEOSBeforeRunIsHonored`, `TestQuitLoopBeforeRunIsHonored`, `TestQuitLoopIsSafeConcurrently`, `TestRunSurvivesTheStartupRace` |
| The bail in `Run` | `TestRunBailsWhenShutdownArrivedFirst` |
| The loop, recreated inside `Run` | `TestRunStopsWhenShutdownArrivesLater` |

The tests drive `Run` itself through a stub `Source`, which is what lets them cover the loop moving back out of `New`. Ordering is established by waiting on `glib.MainContextDefault().Pending` rather than by sleeping, so a quit that lands late cannot make a test pass by way of the case that always worked. `TestDirectQuitBeforeRunIsLost` has a different job: it pins the GStreamer behaviour the fix exists for, so if a future version honours an early quit it fails and says the indirection may be unnecessary.

Nine tests, green under `-race` and `-count=2`; `golangci-lint` clean.

### Known gaps

- **WHIP cannot be interrupted.** `whipAppSource.Start` calls a bare `http.Get` — no request context, no client timeout — so a kill arriving while it is blocked cannot be delivered by the cancel. Giving that call a request context and a timeout, or a process-level watchdog, is a separate change and is not here.
- **The `SendEOS` reorder has no test.** It closes an interleaving a few instructions wide, between `SendEOS` loading a nil cancel and `Run` checking the fuse. Reverting it does not fail the suite: a deterministic test cannot hold that window open without hooks inside both functions.
- **`glib.IdleAdd` attaches to the default main context**, which is the one the loop is built on. A second main loop in this process would share that context, dispatch the source before this loop starts, and lose the quit again — silently. Nothing else in ingress creates a main loop today, so this is latent rather than live.
- **No warning on the racing path.** One was tried and dropped: it was not actionable, and it could miss the case it reported because the check and the loop are not atomic. `starting GST pipeline` with no `GST pipeline stopped` after it is the hang signature, and is what an alert should match on.

### Reviewing

About 48 lines of the diff are re-indentation — unwrapping `closed.Once` moved its body out of a closure, so `gofmt` shifted every line one tab left. `?w=1` on the files view hides them.

The same shape exists in egress at `pkg/gstreamer/pipeline.go`, where `Stop` quits a loop `Run` has not started yet, though `Stop` does `OnStop` plus a full state change to NULL before quitting, so the window is far narrower. Egress already builds its loop in the constructor, so it has no nil exposure. Raised separately; not addressed here.

Fixes CS-1376

🤖 Generated with [Claude Code](https://claude.com/claude-code)
