### PR TITLE
Stop Renovate from bumping modules overridden by a replace directive

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -37,6 +37,15 @@
       "minimumReleaseAge": null
     },
     {
+      "description": "go-gst is overridden by a replace directive pointing at our fork, so its require line is only a version floor and bumping it changes nothing; go-glib is held at the version the fork builds against. Renovate keeps no link between a require line and the replace that overrides it, so this list is maintained by hand alongside go.mod; the fork itself is still updated.",
+      "matchManagers": ["gomod"],
+      "matchPackageNames": [
+        "github.com/go-gst/go-gst",
+        "github.com/go-gst/go-glib"
+      ],
+      "enabled": false
+    },
+    {
       "description": "The go directive is the module minimum, owned by the go toolchain and dependency requirements; the build toolchain is pinned in .go-version instead",
       "matchManagers": ["gomod"],
       "matchDepTypes": ["golang"],


### PR DESCRIPTION
`go.mod` replaces `github.com/go-gst/go-gst` with our `livekit/gst-go` fork, so its `require` line is only a version floor — bumping it changes nothing that gets built. `go-glib` is coupled to the fork (`livekit/gst-go`'s own `go.mod` requires a `go-glib` pseudo-version, and ours pins a slightly newer one), so it is held there too.

Renovate's gomod extractor never looks at `replace` lines — there is no `replace` depType and no link between a `require` entry and the replace that overrides it, so the only way to suppress these is to name the modules. The list is maintained by hand alongside `go.mod`; the fork itself is still updated normally.

Closes the noise from #457 and #456, which Renovate will retire on its next run.

Validated with `renovate-config-validator` (v41). Same change as livekit/egress#1364.

🤖 Generated with [Claude Code](https://claude.com/claude-code)