### PR TITLE
Log source audio and video mime type changes

### DIFF
--- a/pkg/params/params.go
+++ b/pkg/params/params.go
@@ -361,11 +361,17 @@ func (p *Params) SetInputAudioState(ctx context.Context, audioState *livekit.Inp
 		audioState.AverageBitrate = p.State.Audio.AverageBitrate
 	}
 
+	mimeTypeChanged := p.State.Audio.GetMimeType() != audioState.GetMimeType()
+
 	if !proto.Equal(audioState, p.State.Audio) {
 		modified = true
 		p.State.Audio = audioState
 	}
 	p.stateLock.Unlock()
+
+	if mimeTypeChanged {
+		p.logger.Infow("source audio mime type changed", "mimeType", audioState.GetMimeType())
+	}
 
 	if modified && sendUpdateIfModified {
 		p.SendStateUpdate(ctx)
@@ -380,11 +386,17 @@ func (p *Params) SetInputVideoState(ctx context.Context, videoState *livekit.Inp
 		videoState.AverageBitrate = p.State.Video.AverageBitrate
 	}
 
+	mimeTypeChanged := p.State.Video.GetMimeType() != videoState.GetMimeType()
+
 	if !proto.Equal(videoState, p.State.Video) {
 		modified = true
 		p.State.Video = videoState
 	}
 	p.stateLock.Unlock()
+
+	if mimeTypeChanged {
+		p.logger.Infow("source video mime type changed", "mimeType", videoState.GetMimeType())
+	}
 
 	if modified && sendUpdateIfModified {
 		p.SendStateUpdate(ctx)


### PR DESCRIPTION
Emit an info log whenever the mime type reported in the input audio or video state differs from the previously recorded one, so the negotiated source codec and any mid-session changes are visible in the logs.

The comparison is done under `stateLock` against the stored state, and the log is emitted after the lock is released. Note that on the first state update the previous mime type is empty, so the initial detected codec is also logged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)