### PR TITLE
Report an HLS pull that ends short of its source duration as an error

### DIFF
--- a/pkg/media/pipeline.go
+++ b/pkg/media/pipeline.go
@@ -40,6 +40,11 @@ var tracer = otel.Tracer("github.com/livekit/ingress/pkg/media")
 
 const (
 	creationTimeout = 10 * time.Second
+
+	// How much of the advertised duration playback may miss and still count as
+	// complete, as a percentage of it. A manifest duration is the sum of its
+	// segment durations, and the final segment can be shorter than it declares.
+	durationTolerancePercent = 5.0
 )
 
 type Pipeline struct {
@@ -274,6 +279,19 @@ func (p *Pipeline) messageWatch(msg *gst.Message) bool {
 	case gst.MessageEOS:
 		// EOS received - close and return
 		logger.Debugw("EOS received, stopping pipeline")
+
+		// A NULL pipeline reports no position, so check before the state change.
+		// Skip it when the stop was requested: that ends playback early too, so
+		// it says nothing about the source.
+		if !p.closed.IsBroken() {
+			if err := p.checkSourceComplete(); err != nil {
+				select {
+				case p.pipelineErr <- err:
+				default:
+				}
+			}
+		}
+
 		_ = p.pipeline.BlockSetState(gst.StateNull)
 		p.loop.Quit()
 		return false
@@ -315,6 +333,40 @@ func (p *Pipeline) messageWatch(msg *gst.Message) bool {
 	}
 
 	return true
+}
+
+// checkSourceComplete returns an error when EOS arrived before the source
+// played out the duration it advertises. A segment fetch that fails for good
+// arrives as an ordinary EOS, so the advertised duration is what separates a
+// truncated pull from a finished one.
+//
+// This catches HLS. A playlist declares no end, so the position query is
+// answered upstream, by what actually arrived. mp4 and matroska do declare an
+// end, so their sinks answer it instead and this returns nil. A source with no
+// duration is complete too: live HLS, RTMP and WHIP.
+func (p *Pipeline) checkSourceComplete() error {
+	ok, d := p.pipeline.QueryDuration(gst.FormatTime)
+	if !ok || d <= 0 {
+		return nil
+	}
+
+	ok, pos := p.pipeline.QueryPosition(gst.FormatTime)
+	if !ok || pos <= 0 {
+		logger.Debugw("no position at EOS, treating the source as complete",
+			"duration", time.Duration(d))
+		return nil
+	}
+
+	duration, position := time.Duration(d), time.Duration(pos)
+	if position+time.Duration(float64(duration)*durationTolerancePercent/100) >= duration {
+		return nil
+	}
+
+	logger.Infow("source ended before the end of the stream",
+		"position", position, "duration", duration)
+
+	return psrpc.NewErrorf(psrpc.Unavailable,
+		"source ended after %s of %s", position, duration)
 }
 
 func (p *Pipeline) handleStreamCollectionMessage(msg *gst.Message) {

--- a/pkg/media/pipeline.go
+++ b/pkg/media/pipeline.go
@@ -280,11 +280,14 @@ func (p *Pipeline) messageWatch(msg *gst.Message) bool {
 		// EOS received - close and return
 		logger.Debugw("EOS received, stopping pipeline")
 
-		// A NULL pipeline reports no position, so check before the state change.
-		// Skip it when the stop was requested: that ends playback early too, so
-		// it says nothing about the source.
+		// A NULL pipeline reports no position, so this sits ahead of the state
+		// change. Skip it when the stop was requested: that ends playback early
+		// too, so it says nothing about the source. The fuse is read twice on
+		// purpose, once to keep the queries off the shutdown path and once after
+		// them, so a stop arriving while they run still wins.
 		if !p.closed.IsBroken() {
-			if err := p.checkSourceComplete(); err != nil {
+			err := p.checkSourceComplete()
+			if err != nil && !p.closed.IsBroken() {
 				select {
 				case p.pipelineErr <- err:
 				default:
@@ -362,7 +365,7 @@ func (p *Pipeline) checkSourceComplete() error {
 		return nil
 	}
 
-	logger.Infow("source ended before the end of the stream",
+	logger.Warnw("source ended before the end of the stream", nil,
 		"position", position, "duration", duration)
 
 	return psrpc.NewErrorf(psrpc.Unavailable,

--- a/pkg/media/pipeline.go
+++ b/pkg/media/pipeline.go
@@ -280,14 +280,12 @@ func (p *Pipeline) messageWatch(msg *gst.Message) bool {
 		// EOS received - close and return
 		logger.Debugw("EOS received, stopping pipeline")
 
-		// A NULL pipeline reports no position, so this sits ahead of the state
-		// change. Skip it when the stop was requested: that ends playback early
-		// too, so it says nothing about the source. The fuse is read twice on
-		// purpose, once to keep the queries off the shutdown path and once after
-		// them, so a stop arriving while they run still wins.
+		// This has to run before the pipeline goes to NULL, since a NULL
+		// pipeline answers no position query. A stop we asked for also ends
+		// playback early, so it says nothing about the source: skip the check
+		// then.
 		if !p.closed.IsBroken() {
-			err := p.checkSourceComplete()
-			if err != nil && !p.closed.IsBroken() {
+			if err := p.checkSourceComplete(); err != nil {
 				select {
 				case p.pipelineErr <- err:
 				default:

--- a/pkg/media/pipeline_test.go
+++ b/pkg/media/pipeline_test.go
@@ -17,9 +17,14 @@ package media
 import (
 	"context"
 	"fmt"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"os/exec"
+	"path"
 	"path/filepath"
+	"strconv"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -546,4 +551,145 @@ func TestEOSAfterARequestedStopQueuesNothing(t *testing.T) {
 		t.Fatalf("a stop we asked for was reported as a truncated source: %v", err)
 	default:
 	}
+}
+
+// The tests above read a wav through filesrc and wavparse, which is not the
+// topology this check exists for: what a duration and a position query answer
+// depends on which element answers them. These serve a real HLS fixture over
+// HTTP through the same souphttpsrc, decodebin3 and hlsdemux2 chain a URL pull
+// builds, so the manifest duration and the position of the last fragment that
+// arrived are the real ones.
+
+const (
+	hlsFixtureSegments = 10
+	hlsGoodSegments    = 3
+)
+
+// newHLSFixture writes a VOD playlist and its segments, and returns the
+// directory along with the duration the playlist advertises.
+func newHLSFixture(t *testing.T, segments int) (string, time.Duration) {
+	t.Helper()
+
+	gst.Init(nil)
+
+	dir := t.TempDir()
+
+	// One buffer per second at the default rate, so num-buffers is roughly the
+	// segment count. max-files=0 keeps every segment; the default prunes them.
+	enc, err := gst.NewPipelineFromString(fmt.Sprintf(
+		"audiotestsrc num-buffers=%d samplesperbuffer=44100 ! audioconvert ! avenc_aac ! aacparse "+
+			"! hlssink2 location=%s/seg%%05d.ts playlist-location=%s/playlist.m3u8 "+
+			"target-duration=1 playlist-length=0 max-files=0",
+		segments, dir, dir))
+	require.NoError(t, err)
+	require.NoError(t, enc.BlockSetState(gst.StatePlaying))
+
+	msg := enc.GetPipelineBus().TimedPopFiltered(
+		gst.ClockTime(60*time.Second), gst.MessageEOS|gst.MessageError)
+	require.NotNil(t, msg, "writing the fixture timed out")
+	require.Equal(t, gst.MessageEOS, msg.Type(), msg.String())
+	require.NoError(t, enc.BlockSetState(gst.StateNull))
+
+	playlist, err := os.ReadFile(filepath.Join(dir, "playlist.m3u8"))
+	require.NoError(t, err)
+	require.Contains(t, string(playlist), "#EXT-X-ENDLIST", "the fixture must be a VOD playlist")
+
+	var advertised float64
+	for _, line := range strings.Split(string(playlist), "\n") {
+		v, ok := strings.CutPrefix(line, "#EXTINF:")
+		if !ok {
+			continue
+		}
+		d, err := strconv.ParseFloat(strings.TrimSuffix(strings.TrimSpace(v), ","), 64)
+		require.NoError(t, err)
+		advertised += d
+	}
+	require.NotZero(t, advertised, "the playlist declared no segments")
+
+	return dir, time.Duration(advertised * float64(time.Second))
+}
+
+// serveHLS serves the fixture and answers segment requests with 500 once
+// goodSegments have been handed out. The playlist keeps returning 200, so the
+// only failure the demuxer sees is on a fragment, which is what turns into an
+// EOS rather than an error.
+func serveHLS(t *testing.T, dir string, goodSegments int) string {
+	t.Helper()
+
+	var served atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		name := path.Base(r.URL.Path)
+		if !strings.HasSuffix(name, ".m3u8") && int(served.Add(1)) > goodSegments {
+			http.Error(w, "upstream unavailable", http.StatusInternalServerError)
+			return
+		}
+		http.ServeFile(w, r, filepath.Join(dir, name))
+	}))
+	t.Cleanup(srv.Close)
+
+	return srv.URL + "/playlist.m3u8"
+}
+
+// runHLSPull builds the chain a URL pull builds and runs it until the bus
+// reports EOS or an error. The sinks do not sync: for HLS the answer is the
+// same either way, because hlsdemux2 leaves segment.stop unset and the sinks
+// cannot answer a position query from their own state.
+func runHLSPull(t *testing.T, url string) (*Pipeline, gst.MessageType) {
+	t.Helper()
+
+	pipeline, err := gst.NewPipelineFromString(fmt.Sprintf(
+		"souphttpsrc location=%s ! queue2 use-buffering=true max-size-buffers=0 "+
+			"! decodebin3 ! queue ! fakesink sync=false", url))
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = pipeline.BlockSetState(gst.StateNull) })
+
+	require.NoError(t, pipeline.Start())
+
+	msg := pipeline.GetPipelineBus().TimedPopFiltered(
+		gst.ClockTime(60*time.Second), gst.MessageEOS|gst.MessageError)
+	require.NotNil(t, msg, "the pull neither finished nor failed")
+
+	return &Pipeline{pipeline: pipeline}, msg.Type()
+}
+
+// The reported case, over the topology it was reported on. A 5xx part way
+// through has to reach us as an EOS, the duration has to stay the manifest's
+// rather than what was delivered, and the position has to be where the
+// fragments stopped.
+func TestTruncatedHLSPullIsAnError(t *testing.T) {
+	dir, advertised := newHLSFixture(t, hlsFixtureSegments)
+
+	p, msgType := runHLSPull(t, serveHLS(t, dir, hlsGoodSegments))
+
+	require.Equal(t, gst.MessageEOS, msgType,
+		"a fragment 5xx must arrive as an EOS; a bus error would mean this check is not what catches it")
+
+	ok, d := p.pipeline.QueryDuration(gst.FormatTime)
+	require.True(t, ok)
+	require.InDelta(t, advertised.Seconds(), time.Duration(d).Seconds(), 0.5,
+		"duration must be what the manifest advertises, not what arrived")
+
+	ok, pos := p.pipeline.QueryPosition(gst.FormatTime)
+	require.True(t, ok)
+	require.InDelta(t, float64(hlsGoodSegments), time.Duration(pos).Seconds(), 1,
+		"position must reflect the fragments that arrived")
+
+	require.Error(t, p.checkSourceComplete())
+}
+
+// The same topology playing to the end of its playlist has to stay complete,
+// which is what keeps the tolerance from failing an ordinary HLS finish.
+func TestCompleteHLSPullIsComplete(t *testing.T) {
+	dir, advertised := newHLSFixture(t, hlsFixtureSegments)
+
+	p, msgType := runHLSPull(t, serveHLS(t, dir, hlsFixtureSegments+1))
+
+	require.Equal(t, gst.MessageEOS, msgType)
+
+	ok, pos := p.pipeline.QueryPosition(gst.FormatTime)
+	require.True(t, ok)
+	require.InDelta(t, advertised.Seconds(), time.Duration(pos).Seconds(), 0.5,
+		"the whole playlist should have played out")
+
+	require.NoError(t, p.checkSourceComplete())
 }

--- a/pkg/media/pipeline_test.go
+++ b/pkg/media/pipeline_test.go
@@ -16,8 +16,10 @@ package media
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -364,4 +366,184 @@ func runChild(t *testing.T, testName string) ([]byte, error) {
 	cmd.Env = append(os.Environ(), eosChildEnv+"=1")
 
 	return cmd.CombinedOutput()
+}
+
+// A pull that stops short of the duration its source advertises is how an
+// upstream failure reaches us: adaptivedemux2 turns repeated segment fetch
+// failures into an EOS no different from the one a finished source raises.
+// These drive the check over a real pipeline, because what it reads is
+// GStreamer's answer to a duration and a position query rather than anything
+// computed here.
+
+const testSourceLength = 20 * time.Second
+
+// newSeekablePipeline writes a wav of the given length and returns a Pipeline
+// reading it, prerolled so both queries answer. PAUSED is enough: a position
+// query is served from the sink's preroll, so nothing plays out in real time.
+func newSeekablePipeline(t *testing.T, length time.Duration) *Pipeline {
+	t.Helper()
+
+	gst.Init(nil)
+
+	path := filepath.Join(t.TempDir(), "tone.wav")
+
+	// One buffer per second, so num-buffers is the length in seconds.
+	enc, err := gst.NewPipelineFromString(fmt.Sprintf(
+		"audiotestsrc num-buffers=%d samplesperbuffer=44100 ! audioconvert ! wavenc ! filesink location=%s",
+		int(length.Seconds()), path))
+	require.NoError(t, err)
+	require.NoError(t, enc.BlockSetState(gst.StatePlaying))
+
+	msg := enc.GetPipelineBus().TimedPopFiltered(
+		gst.ClockTime(30*time.Second), gst.MessageEOS|gst.MessageError)
+	require.NotNil(t, msg, "writing the fixture timed out")
+	require.Equal(t, gst.MessageEOS, msg.Type(), msg.String())
+	require.NoError(t, enc.BlockSetState(gst.StateNull))
+
+	read, err := gst.NewPipelineFromString(fmt.Sprintf(
+		"filesrc location=%s ! wavparse ! fakesink sync=false", path))
+	require.NoError(t, err)
+	require.NoError(t, read.BlockSetState(gst.StatePaused))
+	t.Cleanup(func() { _ = read.BlockSetState(gst.StateNull) })
+
+	return &Pipeline{pipeline: read}
+}
+
+// stopAt leaves the pipeline reporting pos as its position. A flushing seek
+// re-prerolls, so the new position is waited for rather than assumed.
+func stopAt(t *testing.T, p *Pipeline, pos time.Duration) {
+	t.Helper()
+
+	require.True(t, p.pipeline.SeekTime(pos, gst.SeekFlagFlush|gst.SeekFlagAccurate),
+		"seek to %s failed", pos)
+	p.pipeline.GetState(gst.StatePaused, gst.ClockTime(10*time.Second))
+
+	ok, got := p.pipeline.QueryPosition(gst.FormatTime)
+	require.True(t, ok, "the pipeline reported no position after seeking")
+	require.InDelta(t, pos.Seconds(), time.Duration(got).Seconds(), 0.5,
+		"seek did not land where the test needs it")
+}
+
+// The reported case: the source stopped far short of its duration.
+func TestSourceStoppingShortOfItsDurationIsAnError(t *testing.T) {
+	p := newSeekablePipeline(t, testSourceLength)
+
+	stopAt(t, p, 2*time.Second)
+
+	err := p.checkSourceComplete()
+
+	require.Error(t, err, "stopping 2s into %s must not be reported complete", testSourceLength)
+	require.Contains(t, err.Error(), "source ended after")
+}
+
+// Playing out the whole source is the ordinary end and must stay complete.
+func TestSourcePlayedToItsDurationIsComplete(t *testing.T) {
+	p := newSeekablePipeline(t, testSourceLength)
+
+	stopAt(t, p, testSourceLength)
+
+	require.NoError(t, p.checkSourceComplete())
+}
+
+// Missing a slice smaller than the tolerance is the ordinary end of a source
+// whose final segment ran shorter than the manifest declared.
+func TestStoppingWithinTheToleranceIsComplete(t *testing.T) {
+	const length = 60 * time.Second
+
+	p := newSeekablePipeline(t, length)
+
+	// 2s of 60s is under the tolerance.
+	stopAt(t, p, length-2*time.Second)
+
+	require.NoError(t, p.checkSourceComplete())
+}
+
+// The tolerance is a share of the source, not a fixed span, so the same
+// shortfall means different things on different lengths. A fixed tolerance
+// wide enough for the long source would call the short one complete too.
+func TestToleranceIsProportionalToTheSource(t *testing.T) {
+	const shortfall = 2 * time.Second
+
+	short := newSeekablePipeline(t, testSourceLength)
+	stopAt(t, short, testSourceLength-shortfall)
+	require.Error(t, short.checkSourceComplete(),
+		"%s of %s is past the tolerance", shortfall, testSourceLength)
+
+	long := newSeekablePipeline(t, 60*time.Second)
+	stopAt(t, long, 60*time.Second-shortfall)
+	require.NoError(t, long.checkSourceComplete(),
+		"%s of 1m0s is within the tolerance", shortfall)
+}
+
+// Live HLS along with the RTMP and WHIP inputs have no end to fall short of,
+// so the check has to leave them alone.
+//
+// The two query assertions carry this test. GStreamer answers a duration query
+// for such a source rather than declining it, and reports the unknown duration
+// as a negative value, which is why the guard reads the value and not the
+// boolean. Were that to change, the whole path would shift.
+func TestSourceWithoutDurationIsComplete(t *testing.T) {
+	gst.Init(nil)
+
+	live, err := gst.NewPipelineFromString("audiotestsrc is-live=true ! fakesink sync=false")
+	require.NoError(t, err)
+	require.NoError(t, live.BlockSetState(gst.StatePlaying))
+	t.Cleanup(func() { _ = live.BlockSetState(gst.StateNull) })
+
+	p := &Pipeline{pipeline: live}
+
+	ok, d := p.pipeline.QueryDuration(gst.FormatTime)
+	require.True(t, ok, "the duration query is answered even with no duration to give")
+	require.Negative(t, d, "an unknown duration is reported as a negative value")
+
+	require.NoError(t, p.checkSourceComplete())
+}
+
+// The check hangs off the EOS branch of messageWatch, and two things there
+// carry it: it has to run while the pipeline can still answer a position
+// query, and it has to stay out of the way of a stop we asked for.
+
+// newTruncatedPipeline returns a Pipeline sitting well short of its duration,
+// wired with the parts messageWatch touches.
+func newTruncatedPipeline(t *testing.T) *Pipeline {
+	t.Helper()
+
+	p := newSeekablePipeline(t, testSourceLength)
+	p.loop = glib.NewMainLoop(glib.MainContextDefault(), false)
+	p.pipelineErr = make(chan error, 1)
+	stopAt(t, p, 2*time.Second)
+
+	return p
+}
+
+// Driving the real branch also pins the ordering: the check has to precede the
+// state change, since a NULL pipeline reports no position.
+func TestEOSFromTheSourceQueuesTheTruncation(t *testing.T) {
+	p := newTruncatedPipeline(t)
+
+	p.messageWatch(gst.NewEOSMessage(p.pipeline))
+
+	select {
+	case err := <-p.pipelineErr:
+		require.ErrorContains(t, err, "source ended after")
+	default:
+		t.Fatal("nothing queued: the check either did not run, " +
+			"or ran once the pipeline could no longer report a position")
+	}
+}
+
+// A stop we asked for ends playback early too. Reporting that as a truncated
+// source would fail every ingress a caller deletes part way through.
+func TestEOSAfterARequestedStopQueuesNothing(t *testing.T) {
+	p := newTruncatedPipeline(t)
+
+	p.closed.Break()
+
+	p.messageWatch(gst.NewEOSMessage(p.pipeline))
+
+	select {
+	case err := <-p.pipelineErr:
+		t.Fatalf("a stop we asked for was reported as a truncated source: %v", err)
+	default:
+	}
 }

--- a/test/integration.go
+++ b/test/integration.go
@@ -158,6 +158,9 @@ func RunTestSuite(t *testing.T, conf *TestConfig, bus psrpc.MessageBus, getState
 		t.Run("URL pul", func(t *testing.T) {
 			RunURLTest(t, conf, bus, commandPsrpcClient, psrpcClient, sn, newCmd)
 		})
+		t.Run("URL pull truncated", func(t *testing.T) {
+			RunURLTruncatedTest(t, conf, bus, psrpcClient, sn, newCmd)
+		})
 	}
 
 }

--- a/test/url_truncated.go
+++ b/test/url_truncated.go
@@ -1,0 +1,211 @@
+// Copyright 2023 LiveKit, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build integration
+
+package test
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"os/exec"
+	"path"
+	"path/filepath"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/go-gst/go-gst/gst"
+	"github.com/stretchr/testify/require"
+
+	"github.com/livekit/protocol/livekit"
+	"github.com/livekit/protocol/logger"
+	"github.com/livekit/protocol/rpc"
+	"github.com/livekit/psrpc"
+
+	"github.com/livekit/ingress/pkg/params"
+	"github.com/livekit/ingress/pkg/service"
+	"github.com/livekit/ingress/pkg/utils"
+)
+
+const (
+	truncatedFixtureSegments = 10
+	truncatedGoodSegments    = 3
+)
+
+// writeHLSFixture writes a VOD playlist and its segments into a temporary
+// directory. hlssink2 produces both, so no media is checked in.
+func writeHLSFixture(t *testing.T, segments int) string {
+	t.Helper()
+
+	gst.Init(nil)
+
+	dir := t.TempDir()
+
+	// One buffer per second at the default rate, so num-buffers is roughly the
+	// segment count. max-files=0 keeps every segment; the default prunes them.
+	enc, err := gst.NewPipelineFromString(fmt.Sprintf(
+		"audiotestsrc num-buffers=%d samplesperbuffer=44100 ! audioconvert ! avenc_aac ! aacparse "+
+			"! hlssink2 location=%s/seg%%05d.ts playlist-location=%s/playlist.m3u8 "+
+			"target-duration=1 playlist-length=0 max-files=0",
+		segments, dir, dir))
+	require.NoError(t, err)
+	require.NoError(t, enc.BlockSetState(gst.StatePlaying))
+
+	msg := enc.GetPipelineBus().TimedPopFiltered(
+		gst.ClockTime(60*time.Second), gst.MessageEOS|gst.MessageError)
+	require.NotNil(t, msg, "writing the fixture timed out")
+	require.Equal(t, gst.MessageEOS, msg.Type(), msg.String())
+	require.NoError(t, enc.BlockSetState(gst.StateNull))
+
+	playlist, err := os.ReadFile(filepath.Join(dir, "playlist.m3u8"))
+	require.NoError(t, err)
+	require.Contains(t, string(playlist), "#EXT-X-ENDLIST", "the fixture must be a VOD playlist")
+
+	return dir
+}
+
+// serveTruncatedHLS serves the fixture and answers fragment requests with 500
+// once goodSegments have been handed out, which is the CDN outage this test is
+// about. The playlist keeps returning 200, so the only failure the demuxer sees
+// is on a fragment, and that is what it turns into an EOS.
+func serveTruncatedHLS(t *testing.T, dir string, goodSegments int) string {
+	t.Helper()
+
+	var served atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		name := path.Base(r.URL.Path)
+		if !strings.HasSuffix(name, ".m3u8") && int(served.Add(1)) > goodSegments {
+			http.Error(w, "upstream unavailable", http.StatusInternalServerError)
+			return
+		}
+		http.ServeFile(w, r, filepath.Join(dir, name))
+	}))
+	t.Cleanup(srv.Close)
+
+	return srv.URL + "/playlist.m3u8"
+}
+
+// RunURLTruncatedTest pulls an HLS source whose origin fails part way through
+// and requires the ingress to report an error. GStreamer converts the fragment
+// failures into an EOS indistinguishable from a source that ended, so before
+// this was handled the ingress reported ENDPOINT_COMPLETE and nothing
+// downstream could tell the two apart.
+//
+// The suite needs a message bus of its own. Anything else on the same Redis, a
+// livekit-server or a second ingress, registers its own IOInfoServer and takes a
+// share of the state updates, which surfaces here as an ingress that never
+// reaches a terminal state. A separate Redis instance is required rather than a
+// separate database, since psrpc rides pub/sub and pub/sub is not scoped to one.
+//
+//nolint:revive // TODO(milos) reduce argument count, as with the tests beside this one
+func RunURLTruncatedTest(t *testing.T, conf *TestConfig, bus psrpc.MessageBus, psrpcClient rpc.IOInfoClient, sn utils.StateNotifier, newCmd func(ctx context.Context, p *params.Params) (*exec.Cmd, error)) {
+	svc, err := service.NewService(conf.Config, psrpcClient, sn, bus, nil, nil, newCmd, "")
+	require.NoError(t, err)
+
+	go func() {
+		err := svc.Run()
+		require.NoError(t, err)
+	}()
+
+	t.Cleanup(func() {
+		svc.Stop(true)
+	})
+
+	_, err = rpc.NewIngressInternalServer(svc, bus)
+	require.NoError(t, err)
+
+	internalPsrpcClient, err := rpc.NewIngressInternalClient(bus, psrpc.WithClientTimeout(5*time.Second))
+	require.NoError(t, err)
+
+	updates := make(chan *rpc.UpdateIngressStateRequest, 10)
+	ios := &ioServer{}
+	ios.updateIngressState = func(req *rpc.UpdateIngressStateRequest) error {
+		updates <- req
+		return nil
+	}
+	ios.getIngressInfo = func(_ *rpc.GetIngressInfoRequest) (*rpc.GetIngressInfoResponse, error) {
+		return nil, psrpc.NewErrorf(psrpc.NotFound, "not found")
+	}
+
+	ioPsrpc, err := rpc.NewIOInfoServer(ios, bus)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		ioPsrpc.Kill()
+	})
+
+	url := serveTruncatedHLS(t, writeHLSFixture(t, truncatedFixtureSegments), truncatedGoodSegments)
+
+	// The id is unique per run: the state notifier rejects an update whose
+	// ingress is older than one it already holds, and this test leaves its
+	// ingress in a terminal state rather than deleting it.
+	id := fmt.Sprintf("ingress_id_truncated_%d", time.Now().UnixNano())
+
+	info := &livekit.IngressInfo{
+		IngressId:           id,
+		InputType:           livekit.IngressInput_URL_INPUT,
+		Name:                "ingress-test-truncated",
+		RoomName:            conf.RoomName,
+		ParticipantIdentity: "ingress-test-truncated",
+		ParticipantName:     "ingress-test-truncated",
+		StreamKey:           id,
+		Url:                 url,
+		Audio: &livekit.IngressAudioOptions{
+			Name:   "audio",
+			Source: 0,
+			EncodingOptions: &livekit.IngressAudioOptions_Options{
+				Options: &livekit.IngressAudioEncodingOptions{
+					AudioCodec: livekit.AudioCodec_OPUS,
+					Bitrate:    64000,
+					DisableDtx: false,
+					Channels:   2,
+				},
+			},
+		},
+	}
+
+	time.Sleep(time.Second)
+
+	logger.Infow("truncated http pull url", "url", info.Url,
+		"goodSegments", truncatedGoodSegments, "totalSegments", truncatedFixtureSegments)
+
+	started, err := internalPsrpcClient.StartIngress(context.Background(), &rpc.StartIngressRequest{Info: info})
+	require.NoError(t, err)
+	require.Equal(t, livekit.IngressState_ENDPOINT_BUFFERING, started.State.Status)
+
+	// The pull ends on its own once the origin starts failing, so wait for a
+	// terminal state rather than deleting the ingress, which would be a stop we
+	// asked for and is deliberately not classified.
+	deadline := time.After(90 * time.Second)
+	for {
+		select {
+		case update := <-updates:
+			switch update.State.Status {
+			case livekit.IngressState_ENDPOINT_ERROR:
+				require.Contains(t, update.State.Error, "source ended after",
+					"the error must say the source stopped short, not something incidental")
+				return
+			case livekit.IngressState_ENDPOINT_COMPLETE, livekit.IngressState_ENDPOINT_INACTIVE:
+				t.Fatalf("a truncated pull was reported as %s: this is the CS-1593 regression",
+					update.State.Status)
+			}
+		case <-deadline:
+			t.Fatal("the ingress never reached a terminal state")
+		}
+	}
+}

--- a/test/url_truncated.go
+++ b/test/url_truncated.go
@@ -112,8 +112,6 @@ func serveTruncatedHLS(t *testing.T, dir string, goodSegments int) string {
 // share of the state updates, which surfaces here as an ingress that never
 // reaches a terminal state. A separate Redis instance is required rather than a
 // separate database, since psrpc rides pub/sub and pub/sub is not scoped to one.
-//
-//nolint:revive // TODO(milos) reduce argument count, as with the tests beside this one
 func RunURLTruncatedTest(t *testing.T, conf *TestConfig, bus psrpc.MessageBus, psrpcClient rpc.IOInfoClient, sn utils.StateNotifier, newCmd func(ctx context.Context, p *params.Params) (*exec.Cmd, error)) {
 	svc, err := service.NewService(conf.Config, psrpcClient, sn, bus, nil, nil, newCmd, "")
 	require.NoError(t, err)


### PR DESCRIPTION
Fixes the reported case in [CS-1593](https://linear.app/livekit/issue/CS-1593/url-ingress-reports-endpoint-complete-instead-of-endpoint-error-when).

## The problem

`adaptivedemux2` converts repeated segment fetch failures into a plain EOS, built as a bare `gst_event_new_eos()` with no detail structure and no reason. It is byte-identical to the EOS a source that genuinely ended raises, so an HLS pull whose origin returns 5xx part way through reports `ENDPOINT_COMPLETE`, and monitoring cannot separate that from a clean finish.

## The fix

`hlsdemux2` implements `get_duration` from the parsed manifest, so the pipeline already knows how long the source should be. Ingress never asked. On EOS, compare playback position against it and fail the ingress when playback missed more than `durationTolerancePercent` of it.

## Before and after

Same commit, same origin, only the patch differing:

| Build | Origin | Reported status | Error field |
|---|---|---|---|
| unpatched | 3 x HTTP 500 | `ENDPOINT_COMPLETE` | (empty) |
| patched | 3 x HTTP 500 | `ENDPOINT_ERROR` | `source ended after 10.005333331s of 1m0s` |
| patched | healthy, 0 x 500 | `ENDPOINT_COMPLETE` | (empty) |

Reproduced with a fake HLS origin that serves real MPEG-TS segments and then answers segment requests with 500 while the playlist keeps returning 200.

## Known limitation, please read

**The reach is HLS.** A truncated mp4 or TS pull is still reported complete, and that is structural rather than incidental. `qtdemux` declares `segment.stop` covering the whole file, so at EOS its sinks answer the position query from their own state and report that stop:

```
<appsink2> configured segment ... stop=0:00:20.000000000
<appsink2> in PAUSED using last 0:00:20.000000000
```

A playlist has no predetermined end, so `hlsdemux2` leaves the stop unset, the sink's own position is invalid, and basesink falls back to an upstream peer query which reaches what actually arrived:

```
<appsink0> configured segment ... stop=99:99:99.999999999
<appsink0> in PAUSED using last 99:99:99.999999999
     -> pipeline reports 10.005333331s of 1m0s, and the check fires
```

Two GStreamer implementation details carry this: that `hlsdemux2` sets no stop, and that the sinks have sync enabled. Neither is a documented contract. If either changes the check goes quiet rather than wrong, but it goes quiet.

## Live sources are unaffected

For a live stream the same conversion happens but `handle_playlist_eos` waits for a manifest update instead of pushing EOS, so no EOS reaches the bus and the check is never called. A live playlist also reports a duration of `-1`. Verified both ways: a live outage still ends `ENDPOINT_ERROR` via GStreamer's own `Couldn't download fragments`, with the new check not invoked.

## Tests

Seven tests drive the check over a real pipeline rather than asserting arithmetic, since what it reads is GStreamer's answer to a duration and a position query. A wav of known length stands in for the manifest and a flushing seek for the point playback stopped at. Two of them drive the EOS branch of `messageWatch` itself, which pins the ordering the check depends on and the exclusion of a stop we asked for.

Each was mutation tested. Six of the seven fail against at least one plausible break: detection removed, the share replaced by a fixed span, the share widened, the tolerance dropped, the comparison inverted, the closed-fuse guard removed, and the check moved after the pipeline goes to NULL. `TestSourceWithoutDurationIsComplete` is the exception: it does not guard our logic (removing the duration guard leaves it green, because a negative duration compares as complete anyway) and is kept as a contract test on GStreamer answering `ok=true` with a negative value.

## Open questions for review

1. **Two queries now precede teardown in the EOS branch.** A GStreamer query can block on a wedged pipeline, and `messageWatch` runs on the main loop. That branch already had an unprotected blocking call, since its `BlockSetState` has no timeout while `SendEOS` wraps the identical call in a goroutine and a 5s timer, so this widens an existing exposure rather than adding a new one. It has not blocked in roughly thirty runs. Wrapping it the way `SendEOS` does would close it.
2. **`durationTolerancePercent = 5.0` is unmeasured.** Healthy sources came within milliseconds of their duration here (HLS VOD `1m0.011s` against `1m0s`, mp4 exact), so it could likely be tightened once there is production data on real assets. It is a float so that tightening can be fractional.
3. **The `d <= 0` arm is untestable.** With a duration of `-1` the comparison reports complete anyway, so no behaviour depends on it. Kept for intent.
4. **The Info log duplicates the returned error text**, though its structured fields query better than parsing an error string.

## Verification

- `golangci-lint run --timeout=5m` via `build/test/Dockerfile`: 0 issues
- Full `go test ./pkg/...` on GStreamer 1.26.7 / Linux, the version production pins: green
- `go test -race` and `-count=3` on the new tests: clean, no flakiness
- End to end against a live ingress on macOS with Homebrew GStreamer 1.28.6

Expect reported ingress error rates to rise by the number of failures currently hidden as `ENDPOINT_COMPLETE`. That is the fix working, but it will read as a regression on dashboards built off `livekit_ingress_results{type="url"}`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
