### PR TITLE
Support opt-in psrpc bus compression

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,16 @@ rtc_config: configuration for ICE and other RTC related settings, same settings 
 enable_udp_url_pull: allow URL pull ingresses to pull from udp:// urls (default false, see the security note below)
 multicast_interface: network interface to join multicast groups on for UDP url pull. Empty lets the OS decide
 
+# optional gzip compression of psrpc bus payloads (see the compatibility note below)
+psrpc:
+  compression:
+    # gzip level 1-9. 0, the default, disables compression
+    quality: 0
+    # payload bytes below which compression is skipped
+    threshold: 1024
+    # cap on an inbound payload after decompression, 0 for unlimited
+    max_decompressed_size: 0
+
 # cpu costs for various Ingress types with their default values
 cpu_cost:
   rtmp_cpu_cost: 2.0
@@ -89,6 +99,16 @@ The config file can be added to a mounted volume with its location passed in the
 > - Have the handler join arbitrary multicast groups and republish whatever it receives into a LiveKit
 >   room, using the ingress as a relay for streams on the handler's local network that the caller has no
 >   direct access to.
+
+> **Compatibility note on `psrpc.compression`**
+>
+> Bus compression requires psrpc v0.7.6 or newer on every node sharing the Redis bus. An older peer
+> ignores the compression marker and tries to decode the gzipped bytes as the message payload, so the
+> message is dropped without an error. Enabling it is therefore a two-stage operator action: roll a
+> build with psrpc v0.7.6+ out to livekit-server, ingress, egress, SIP and any agent workers first,
+> then raise `quality` at the publishers. It is off by default.
+>
+> `max_decompressed_size` only affects reading, so it can be set ahead of `quality`.
 
 In order for the LiveKit server to be able to create Ingress sessions, an `ingress` section must also be added to the livekit-server configuration:
 

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -129,7 +129,7 @@ func runService(_ context.Context, c *cli.Command) error {
 		return err
 	}
 
-	bus := psrpc.NewRedisMessageBus(rc)
+	bus := psrpc.NewRedisMessageBus(rc, conf.PSRPC.BusOptions()...)
 	psrpcClient, err := rpc.NewIOInfoClient(bus)
 	if err != nil {
 		return err

--- a/go.mod
+++ b/go.mod
@@ -15,8 +15,8 @@ require (
 	github.com/livekit/mageutil v0.0.0-20250511045019-0f1ff63f7731
 	github.com/livekit/media-sdk v0.0.0-20260828235137-cb2363a4cb4f
 	github.com/livekit/mediatransportutil v0.0.0-20260821083140-f234b534b095
-	github.com/livekit/protocol v1.50.5-0.20260829123501-a469dd43727b
-	github.com/livekit/psrpc v0.7.5
+	github.com/livekit/protocol v1.51.1-0.20260905133529-a4f4b5c0c23f
+	github.com/livekit/psrpc v0.7.6
 	github.com/livekit/server-sdk-go/v2 v2.18.2-0.20260831001713-a41bea984454
 	github.com/pion/dtls/v3 v3.1.5
 	github.com/pion/interceptor v0.1.47

--- a/go.sum
+++ b/go.sum
@@ -105,10 +105,10 @@ github.com/livekit/media-sdk v0.0.0-20260828235137-cb2363a4cb4f h1:NhAeNlfiQrHZt
 github.com/livekit/media-sdk v0.0.0-20260828235137-cb2363a4cb4f/go.mod h1:TuYRjSepaakL6ATsM9V2VMuksewW1PlhA32BG7Pxty0=
 github.com/livekit/mediatransportutil v0.0.0-20260821083140-f234b534b095 h1:BcliKAXoMhl/nWmzQweQ5kmh4Qqagxl4s3Z5pvM/7AY=
 github.com/livekit/mediatransportutil v0.0.0-20260821083140-f234b534b095/go.mod h1:o8CFmAdrVwzJNOCsQCLUzXRjokkufNshnQHOe4fRaqU=
-github.com/livekit/protocol v1.50.5-0.20260829123501-a469dd43727b h1:OOqCnFt5AZRVdSjYzaOzCR9KiB9IeeTPMGls+C1Ti2g=
-github.com/livekit/protocol v1.50.5-0.20260829123501-a469dd43727b/go.mod h1:x7m1nX86XfvS0YoqXnVe0jixkCmAZglR4mcbRHURSro=
-github.com/livekit/psrpc v0.7.5 h1:WxfJIQ41X1b+48A1uzc8Gy9FhYEMxBJNCpCYqPdO/Ds=
-github.com/livekit/psrpc v0.7.5/go.mod h1:rAI+m2+/cb4x9RXhLRtUx5ZwdfjjXOl4zi46IjEetaw=
+github.com/livekit/protocol v1.51.1-0.20260905133529-a4f4b5c0c23f h1:+48IWNrsoTgbB0JGv+xJl4umx6e/vh1BX1Tcokuacwc=
+github.com/livekit/protocol v1.51.1-0.20260905133529-a4f4b5c0c23f/go.mod h1:zxowkRnQlJ2VMn6ZyinXMDi985wcKXuWNeXmEERqFAs=
+github.com/livekit/psrpc v0.7.6 h1:YG07lUMTtf+eaYI2goT9zcVZ0kGJNWN1K6ETNFtv1HQ=
+github.com/livekit/psrpc v0.7.6/go.mod h1:DMw15RO7x5XmcgfwzWJYk2In605kx+wu1QRVbPfzf8M=
 github.com/livekit/server-sdk-go/v2 v2.18.2-0.20260831001713-a41bea984454 h1:IEstXtUOyZnBE81hLLeWSph5TB6321wwpyiDwDqVaKM=
 github.com/livekit/server-sdk-go/v2 v2.18.2-0.20260831001713-a41bea984454/go.mod h1:KUMe/Urduz48J4wPavycH8fwnEffaYnC4rtFrlx14qE=
 github.com/mackerelio/go-osstat v0.2.8 h1:I2duicTaCGWoM53XwAwA9OIe1inu0xnVs8/pqOWWVr4=

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -24,6 +24,7 @@ import (
 	"github.com/livekit/protocol/logger"
 	"github.com/livekit/protocol/logger/medialogutils"
 	"github.com/livekit/protocol/redis"
+	"github.com/livekit/protocol/rpc"
 	"github.com/livekit/protocol/utils"
 	"github.com/livekit/psrpc"
 	lksdk "github.com/livekit/server-sdk-go/v2"
@@ -52,15 +53,16 @@ type ServiceConfig struct {
 	ApiSecret string             `yaml:"api_secret"` // required (env LIVEKIT_API_SECRET)
 	WsUrl     string             `yaml:"ws_url"`     // required (env LIVEKIT_WS_URL)
 
-	HealthPort       int           `yaml:"health_port"`
-	DebugHandlerPort int           `yaml:"debug_handler_port"`
-	PrometheusPort   int           `yaml:"prometheus_port"`
-	RTMPPort         int           `yaml:"rtmp_port"` // -1 to disable RTMP
-	WHIPPort         int           `yaml:"whip_port"` // -1 to disable WHIP
-	HTTPRelayPort    int           `yaml:"http_relay_port"`
-	Logging          logger.Config `yaml:"logging"`
-	Development      bool          `yaml:"development"`
-	PSRPCSkipClaim   bool          `yaml:"psrpc_skip_claim,omitempty"` // Lets psrpc servers skip the claim handshake on queue rpcs
+	HealthPort       int             `yaml:"health_port"`
+	DebugHandlerPort int             `yaml:"debug_handler_port"`
+	PrometheusPort   int             `yaml:"prometheus_port"`
+	RTMPPort         int             `yaml:"rtmp_port"` // -1 to disable RTMP
+	WHIPPort         int             `yaml:"whip_port"` // -1 to disable WHIP
+	HTTPRelayPort    int             `yaml:"http_relay_port"`
+	Logging          logger.Config   `yaml:"logging"`
+	Development      bool            `yaml:"development"`
+	PSRPCSkipClaim   bool            `yaml:"psrpc_skip_claim,omitempty"` // Lets psrpc servers skip the claim handshake on queue rpcs
+	PSRPC            rpc.PSRPCConfig `yaml:"psrpc,omitempty"`
 	// Allow URL pull ingresses to pull from udp:// urls. Disabled by default, and should only be
 	// enabled on deployments where both the API callers and the network the handlers run on are trusted.
 	// Unlike the http and srt sources, udpsrc doesn't connect out to the url host: it binds a local
@@ -108,6 +110,7 @@ func NewConfig(confString string) (*Config, error) {
 			ApiKey:    os.Getenv("LIVEKIT_API_KEY"),
 			ApiSecret: os.Getenv("LIVEKIT_API_SECRET"),
 			WsUrl:     os.Getenv("LIVEKIT_WS_URL"),
+			PSRPC:     rpc.DefaultPSRPCConfig,
 		},
 		InternalConfig: &InternalConfig{
 			ServiceName: "ingress",

--- a/test/integration.go
+++ b/test/integration.go
@@ -100,7 +100,7 @@ func (s *ioServer) RecordCallContext(context.Context, *rpc.RecordCallContextRequ
 func GetDefaultConfig() *TestConfig {
 	tc := &TestConfig{
 		Config: &config.Config{
-			ServiceConfig:  &config.ServiceConfig{},
+			ServiceConfig:  &config.ServiceConfig{PSRPC: rpc.DefaultPSRPCConfig},
 			InternalConfig: &config.InternalConfig{},
 		},
 	}

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -34,7 +34,7 @@ func TestIngress(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, rc, "redis required")
 
-	bus := psrpc.NewRedisMessageBus(rc)
+	bus := psrpc.NewRedisMessageBus(rc, conf.PSRPC.BusOptions()...)
 
 	RunTestSuite(t, conf, bus, func(psrpcClient rpc.IOInfoClient) utils.StateNotifier {
 		return utils.NewServiceStateNotifier(psrpcClient)


### PR DESCRIPTION
psrpc v0.7.6 ([psrpc#130](https://github.com/livekit/psrpc/pull/130)) added opt-in gzip at the bus boundary, and [protocol#1771](https://github.com/livekit/protocol/pull/1771) surfaced it as `rpc.PSRPCConfig.Compression` with a `BusOptions()` conversion. `runService` built the bus from the redis client alone, so there was no way to reach the setting.

```yaml
psrpc:
  compression:
    quality: 6
    threshold: 1024
    max_decompressed_size: 0
```

### Shape

Ingress carried no `rpc.PSRPCConfig` at all, only a top-level `psrpc_skip_claim` bool, so this adds the whole block under a `psrpc:` key. That matches the layout livekit-server uses ([livekit#4844](https://github.com/livekit/livekit/pull/4844)) and gives egress and SIP a shape to copy — neither has done this yet.

It is seeded in `NewConfig` rather than `InitDefaults`, because the handler subprocess parses its config with `initialize=false`. Without the seed, a config setting only `quality` would leave `Threshold` at zero and compress every payload, however small.

The service process holds the only bus. The per-session handler subprocess talks to the parent over unix-socket gRPC IPC and never builds one, so nothing else needed threading. The integration suite bypasses `NewConfig`, so `GetDefaultConfig` carries the same seed.

### Compression is off by default

A peer on psrpc older than v0.7.6 ignores the compression marker — psrpc deserializes with `DiscardUnknown` — and then decodes the gzipped bytes as the payload, so the message is dropped without an error. livekit-server, egress, SIP and agent workers share this bus, so enabling it is a two-stage operator action: roll v0.7.6+ everywhere, then raise `quality` at the publishers. The README says so at the setting.

`max_decompressed_size` only affects reading, so it can be set ahead of `quality`.

### Testing

`pkg/config/config_test.go` is new; the package had no tests. It covers the defaults and an override that leaves `Threshold` at its default.

Verified the config actually reaches the compressor with a throwaway psrpc echo RPC over a local bus: the default config round-trips, `quality: 6` with `threshold: 1` round-trips, and adding `max_decompressed_size: 64` drops that same 16 KB payload — which is what proves it was gzipped rather than skipped by the threshold. `quality: 0` with the same cap delivers it.

Not verified against a live livekit-server; that needs a peer already on psrpc v0.7.6+.

### Note on the protocol pin

`v1.51.1-0.20260905133529-a4f4b5c0c23f` is protocol main at the `#1771` merge, the same pseudo-version livekit#4844 uses. It is 14 commits ahead of the previous pin and otherwise additive.