### PR TITLE
drain the handler ipc server before the process exits

### DIFF
--- a/pkg/ipc/conn.go
+++ b/pkg/ipc/conn.go
@@ -95,13 +95,13 @@ func (ihc *IngressHandlerClientWrapper) Close() error {
 	return ihc.conn.Close()
 }
 
-func StartHandlerServer(tmpDir string, h IngressHandlerServer) error {
+func StartHandlerServer(tmpDir string, h IngressHandlerServer) (*grpc.Server, error) {
 	socketAddr := getHandlerSocketAddress(tmpDir)
 	os.Remove(socketAddr)
 
 	listener, err := net.Listen(network, socketAddr)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	grpcServer := grpc.NewServer()
@@ -115,7 +115,7 @@ func StartHandlerServer(tmpDir string, h IngressHandlerServer) error {
 		}
 	}()
 
-	return nil
+	return grpcServer, nil
 }
 
 func getServiceSocketAddress(handlerTmpDir string) string {

--- a/pkg/ipc/conn_test.go
+++ b/pkg/ipc/conn_test.go
@@ -29,9 +29,11 @@ type testHandler struct {
 func TestStartHandlerServerRebindsExistingSocket(t *testing.T) {
 	tmpDir := testutil.ShortTempDir(t)
 
-	require.NoError(t, StartHandlerServer(tmpDir, &testHandler{}))
+	_, err := StartHandlerServer(tmpDir, &testHandler{})
+	require.NoError(t, err)
 
 	// a relaunched handler must be able to bind after a previous process
 	// died without unlinking its socket
-	require.NoError(t, StartHandlerServer(tmpDir, &testHandler{}))
+	_, err = StartHandlerServer(tmpDir, &testHandler{})
+	require.NoError(t, err)
 }

--- a/pkg/service/handler.go
+++ b/pkg/service/handler.go
@@ -18,6 +18,8 @@ import (
 	"context"
 	"time"
 
+	"google.golang.org/grpc"
+
 	"github.com/frostbyte73/core"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -35,6 +37,10 @@ import (
 	"github.com/livekit/ingress/pkg/stats"
 	"github.com/livekit/ingress/pkg/utils"
 )
+
+// ipcDrainTimeout bounds how long a handler waits for in-flight IPC calls to
+// answer before it exits.
+const ipcDrainTimeout = 5 * time.Second
 
 type Handler struct {
 	ipc.UnimplementedIngressHandlerServer
@@ -77,13 +83,18 @@ func (h *Handler) HandleIngress(ctx context.Context, info *livekit.IngressInfo, 
 	}
 	h.pipeline = p
 
-	err = ipc.StartHandlerServer(p.TmpDir, h)
+	ipcServer, err := ipc.StartHandlerServer(p.TmpDir, h)
 	if err != nil {
 		span.RecordError(err)
 		logger.Errorw("failed starting hander server", err)
 		h.publishFinalState(ctx, p.Params, err)
 		return err
 	}
+
+	// Returning from here ends the process, so drain the IPC server first.
+	// KillIngress answers once the session is over, and its reply has to reach
+	// the caller before the process goes away.
+	defer drainIPCServer(ipcServer)
 
 	// start ingress
 	result := make(chan error, 1)
@@ -95,8 +106,10 @@ func (h *Handler) HandleIngress(ctx context.Context, info *livekit.IngressInfo, 
 		// lets the process exit, so publishing later races both.
 		h.publishFinalState(ctx, p.Params, err)
 
-		result <- err
+		// Break before signaling the loop: an in-flight KillIngress is
+		// waiting on this, and the drain on the way out waits on that.
 		h.done.Break()
+		result <- err
 	}()
 
 	kill := h.kill.Watch()
@@ -113,6 +126,24 @@ func (h *Handler) HandleIngress(ctx context.Context, info *livekit.IngressInfo, 
 			span.RecordError(err)
 			return err
 		}
+	}
+}
+
+// drainIPCServer lets in-flight IPC calls answer before the process exits, and
+// gives up rather than blocking forever: a handler that cannot drain is about
+// to be killed by the service anyway.
+func drainIPCServer(srv *grpc.Server) {
+	stopped := make(chan struct{})
+	go func() {
+		srv.GracefulStop()
+		close(stopped)
+	}()
+
+	select {
+	case <-stopped:
+	case <-time.After(ipcDrainTimeout):
+		logger.Infow("ipc server did not drain, stopping it")
+		srv.Stop()
 	}
 }
 


### PR DESCRIPTION
Fixes a regression I introduced in #483. The integration suite fails on `DeleteIngress` with `error reading from server: EOF`.

## What happens

`KillIngress` answers once the session is over — `killAndReturnState` waits on `h.done` and returns the final state as its reply. Returning from `HandleIngress` ends the process, and nothing waited for that reply to reach the wire.

That window has always existed. `StartHandlerServer` spawned `grpcServer.Serve(listener)` in a goroutine, returned only an `error`, and kept no handle, so the server was never stopped — it just died with the process.

It was covered by accident. Publishing the final state used to happen *after* `h.done` broke, in the select loop, and that publish is a synchronous IPC call — it held the process open long enough for the `KillIngress` reply to flush. #483 moved the publish before `h.done` so `killAndReturnState` would stop returning a non-terminal state, and the window collapsed to nothing.

## Fix

`StartHandlerServer` returns its `*grpc.Server`, matching `StartServiceServer`, and `HandleIngress` drains it on the way out.

The drain is bounded rather than a bare `GracefulStop`: a handler that cannot drain is about to be SIGKILLed by the service a second after termination was requested, so blocking indefinitely would only delay that.

`h.done` now breaks before the result is sent, so an in-flight `KillIngress` is already unblocked when the drain starts, instead of the drain depending on goroutine scheduling to make progress.

## Evidence

On the downstream integration suite, the same consumer code passed against the pre-#483 pin and failed three times consecutively against `785337c`. The failure is at `test/rtmp.go:137`, immediately after `DeleteIngress`.

## Verification

`go build ./...`, `go vet ./pkg/...` and `go test -count=1 ./pkg/...` clean — 8 packages.

`TestStartHandlerServerRebindsExistingSocket` covers the changed signature. The drain itself has no unit test: it needs a live handler process and an in-flight IPC call, and the real check is the downstream integration suite that caught this. I will confirm there once this lands.

## Worth noting separately

The downstream `Test` workflow last ran on its `main` branch in July. Had it run per-merge, this would have surfaced against ingress `main` rather than in an unrelated PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)