### PR TITLE
call ready before starting the goroutine that calls ended

### DIFF
--- a/pkg/whip/server.go
+++ b/pkg/whip/server.go
@@ -399,31 +399,30 @@ func (s *WHIPServer) createStream(streamKey string, sdpOffer string, ua string) 
 		ctx, done := context.WithTimeout(s.ctx, sessionStartTimeout)
 		defer done()
 
-		var err error
-		var mimeTypes map[types.StreamKind]string
-		if ready != nil {
-			defer func() {
-				stats := ready(mimeTypes, err)
-				if stats != nil {
-					h.SetMediaStatsGatherer(stats)
-				}
-
-				if err != nil {
-					h.Close()
-
-					s.handlersLock.Lock()
-					delete(s.handlers, resourceId)
-					s.handlersLock.Unlock()
-				}
-			}()
-		}
-
 		s.handlersLock.Lock()
 		s.handlers[resourceId] = h
 		s.handlersLock.Unlock()
 
-		mimeTypes, err = h.Start(ctx)
+		mimeTypes, err := h.Start(ctx)
+
+		// Call ready here rather than on the way out. The goroutine below
+		// calls ended, and a session whose done channel is already broken
+		// reaches ended without blocking, so deferring ready lets ended
+		// overtake it -- ready sends a state update, and the round trip is
+		// long enough for the whole of ended to run in the middle of it.
+		if ready != nil {
+			if stats := ready(mimeTypes, err); stats != nil {
+				h.SetMediaStatsGatherer(stats)
+			}
+		}
+
 		if err != nil {
+			h.Close()
+
+			s.handlersLock.Lock()
+			delete(s.handlers, resourceId)
+			s.handlersLock.Unlock()
+
 			return
 		}
 


### PR DESCRIPTION
Stacked on #491. Review that first; this branch is one file.

## The defect

`createStream` hands the caller `ready` and `ended` as a pair with no ordering between them. `ready` was deferred, so it ran on the way *out* of the goroutine that launches the one calling `ended`:

```go
go func() {
    if ready != nil {
        defer func() { stats := ready(mimeTypes, err) }()   // runs last
    }
    mimeTypes, err = h.Start(ctx)
    ...
    go func() {                                            // launched first
        defer func() { ended(err) }()
        err = h.WaitForSessionEnd(s.ctx)
    }()
}()
```

For a bypassed WHIP session that is already over, `WaitForSessionEnd` selects on an already-broken `done` and returns without blocking. `Init` registers the RTC notify topic before it returns, so the SFU can break `done` at any point after the SDP exchange — a publisher whose connection fails during the handshake, a client that hangs up on the answer, an immediate resource delete.

This is not a narrow scheduling window. `ready`'s second statement is `SendStateUpdate`, a psrpc round trip, so `ready` parks about two statements in and hands its P to the goroutine sitting in `runnext`. `ended` then runs to completion in the middle of it:

```
ready:  SetStatus(PUBLISHING) -> SendStateUpdate --park---------------+
ended:                          SetStatus(INACTIVE) -> SendStateUpdate|
                                SessionEnded -> IngressEnded          |
ready:  <-------------------------------------------------------------+
        IngressStarted -> SessionStarted     <- registers a dead session
```

Three consequences: the terminal state is overwritten by `PUBLISHING` (`SetStatus` has no terminal guard, last write wins); the notifier is told a released session started; and `IngressStarted` lands after `IngressEnded`, leaving an entry in the session manager that nothing removes, so `IsIdle` never comes true and shutdown does not complete.

Only bypassed WHIP is affected — `ended` is non-nil only under `!*p.EnableTranscoding`. Every other input registers synchronously inside `ready` and is handed a nil `ended`.

## The fix

Call `ready` inline, before the goroutine that calls `ended` exists. There was exactly one `return` between the defer and the `go`, so the restructure is mechanical: the deferred body becomes straight-line code and the error branch keeps its own `return`.

No synchronization primitive. A `sync.Once` would force `ended` to synthesize a `ready(nil, err)` it has no arguments for, which rewrites a clean short session's terminal state to `ENDPOINT_ERROR`; a channel barrier works but deadlocks if `ready` is ever nil, since the close sits under the same `if`.

The only thing lost is panic-unwinding coverage, which was not real — nothing recovers here, so the process dies either way.

## Verification

`go build ./...`, `go vet ./pkg/...`, `go test -count=1 ./pkg/...` — 8 packages, all pass.

Not covered by a test: `createStream` reaches the race only through a live SFU HTTP exchange in `Init` and a psrpc-backed notifier, neither of which has a seam here.