### PR TITLE
fix: take a failed session through the full shutdown

### DIFF
--- a/pkg/media/pipeline.go
+++ b/pkg/media/pipeline.go
@@ -16,6 +16,7 @@ package media
 
 import (
 	"context"
+	"errors"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -225,7 +226,9 @@ func (p *Pipeline) fail(err error) {
 	}
 
 	p.SetStatus(livekit.IngressState_ENDPOINT_ERROR, err)
-	p.quitLoop()
+
+	// SendEOS runs the full shutdown: it cancels the input and stops the loop.
+	p.SendEOS(context.Background())
 
 	p.SendStateUpdate(context.Background())
 }
@@ -286,15 +289,27 @@ func (p *Pipeline) Run(ctx context.Context) error {
 		err = sinkErr
 	}
 
-	if err == nil {
-		// Retrieve any pipeline error
-		select {
-		case err = <-p.pipelineErr:
-		default:
-		}
+	return resolveRunError(err, p.pipelineErr)
+}
+
+// resolveRunError picks what Run reports from the error the pipeline shut down
+// with and any cause recorded on the way down.
+//
+// A cancellation is how the shutdown unblocks a source that is waiting on
+// bytes, so it describes the teardown rather than what caused it. A recorded
+// cause is preferred over one. Anything else stands: a genuine input failure is
+// more upstream than anything recorded downstream of it.
+func resolveRunError(err error, recorded <-chan error) error {
+	if err != nil && !errors.Is(err, context.Canceled) {
+		return err
 	}
 
-	return err
+	select {
+	case cause := <-recorded:
+		return cause
+	default:
+		return err
+	}
 }
 
 func (p *Pipeline) messageWatch(msg *gst.Message) bool {

--- a/pkg/media/pipeline_test.go
+++ b/pkg/media/pipeline_test.go
@@ -16,6 +16,7 @@ package media
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -36,6 +37,7 @@ import (
 
 	"github.com/livekit/ingress/pkg/config"
 	"github.com/livekit/ingress/pkg/params"
+	"github.com/livekit/ingress/pkg/stats"
 	"github.com/livekit/ingress/pkg/types"
 	"github.com/livekit/ingress/pkg/utils"
 	"github.com/livekit/protocol/livekit"
@@ -734,12 +736,9 @@ func newTestParams(t *testing.T, sn utils.StateNotifier) *params.Params {
 func TestTrackBuildFailureStopsTheSession(t *testing.T) {
 	gst.Init(nil)
 
-	p := &Pipeline{
-		Params:      newTestParams(t, utils.NewNoopStateNotifier()),
-		loop:        glib.NewMainLoop(glib.MainContextDefault(), false),
-		pipelineErr: make(chan error, 1),
-		established: make(map[types.StreamKind]string),
-	}
+	p := newTestPipeline(t)
+	p.Params = newTestParams(t, utils.NewNoopStateNotifier())
+	p.established = make(map[types.StreamKind]string)
 
 	go p.loop.Run()
 	require.Eventually(t, p.loop.IsRunning, 2*time.Second, 10*time.Millisecond, "loop did not start")
@@ -779,12 +778,9 @@ func TestTrackBuildFailureStopsTheSessionWhileReportingStalls(t *testing.T) {
 	release := make(chan struct{})
 	defer close(release)
 
-	p := &Pipeline{
-		Params:      newTestParams(t, stalledNotifier{release}),
-		loop:        glib.NewMainLoop(glib.MainContextDefault(), false),
-		pipelineErr: make(chan error, 1),
-		established: make(map[types.StreamKind]string),
-	}
+	p := newTestPipeline(t)
+	p.Params = newTestParams(t, stalledNotifier{release})
+	p.established = make(map[types.StreamKind]string)
 
 	pad := newCapsHoldingGhostPad(t, testCapsWithoutResolution)
 	returned := startLoop(p)
@@ -800,5 +796,81 @@ func TestTrackBuildFailureStopsTheSessionWhileReportingStalls(t *testing.T) {
 		require.Error(t, err, "Run must still end with the track failure as its cause")
 	default:
 		t.Fatal("no cause was handed to Run")
+	}
+}
+
+// A cancellation is how the shutdown unblocks the input, so it must not be what
+// Run reports when a cause was recorded.
+func TestResolveRunErrorPrefersRecordedCause(t *testing.T) {
+	cause := errors.New("could not add video track")
+
+	recorded := func() <-chan error {
+		c := make(chan error, 1)
+		c <- cause
+		return c
+	}
+	empty := func() <-chan error { return make(chan error, 1) }
+
+	require.Equal(t, cause, resolveRunError(context.Canceled, recorded()),
+		"a cancellation must not mask the recorded cause")
+	require.Equal(t, cause, resolveRunError(nil, recorded()))
+	require.Equal(t, cause, resolveRunError(fmt.Errorf("closing: %w", context.Canceled), recorded()),
+		"a wrapped cancellation must not mask it either")
+
+	require.Equal(t, context.Canceled, resolveRunError(context.Canceled, empty()),
+		"with nothing recorded the shutdown error stands, so a kill still reports as it did")
+
+	inputErr := errors.New("relay returned 500")
+	require.Equal(t, inputErr, resolveRunError(inputErr, recorded()),
+		"a genuine input failure is more upstream than anything recorded downstream")
+}
+
+// A track failure ends the session even when the publisher is connected and
+// sending nothing, which leaves the relay read with no bytes to return.
+func TestTrackBuildFailureClosesAStalledInput(t *testing.T) {
+	gst.Init(nil)
+
+	// A relay that answers, then goes quiet.
+	hold := make(chan struct{})
+	relay := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		w.(http.Flusher).Flush()
+		<-hold
+	}))
+	defer relay.Close()
+	defer close(hold)
+
+	p := newTestPipeline(t)
+	p.Params = newTestParams(t, utils.NewNoopStateNotifier())
+	p.RelayUrl = relay.URL
+	p.established = make(map[types.StreamKind]string)
+
+	input, err := NewInput(context.Background(), p.Params, stats.NewLocalMediaStatsGatherer())
+	require.NoError(t, err)
+	p.input = input
+
+	// Run stores the cancel for the context it hands the input.
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	p.cancel.Store(&cancel)
+	require.NoError(t, input.Start(ctx, func(context.Context) {}))
+
+	// Let the relay read park with nothing to read.
+	time.Sleep(300 * time.Millisecond)
+
+	returned := startLoop(p)
+
+	p.onParamsReady(types.Video, newCapsHoldingGhostPad(t, testCapsWithoutResolution))
+
+	require.True(t, stoppedWithin(returned, 5*time.Second),
+		"the session kept running after a track failed to build")
+
+	closed := make(chan error, 1)
+	go func() { closed <- p.input.Close() }()
+
+	select {
+	case <-closed:
+	case <-time.After(5 * time.Second):
+		t.Fatal("the input was left waiting on a relay read that may never return")
 	}
 }


### PR DESCRIPTION
Follow-up to #482, answering [Milos's comment](https://github.com/livekit/ingress/pull/482#issuecomment-5569490620) on it. Fixes CS-2029's remaining half.

## Problem

A track that cannot be built ends the session by quitting the main loop. `Run` then closes the input, and for RTMP that close waits down a chain that ends at the network:

```
Run -> input.Close -> RTMPRelaySource.Close -> <-s.result -> io.Copy -> the next bytes from the relay
```

A publisher can hold its connection open while sending nothing: a paused encoder, a network stall, a client keeping the socket alive. `RTMPRelaySource` reads inline with `io.Copy`, and its only stop signal is an EOS flag checked inside `appSrcWriter.Write`, which only runs after a read returns bytes. So the flag cannot be delivered while the read is parked, and the teardown waits until the publisher sends a byte or disconnects.

Measured, with a real `Input` over a relay that answers and then goes quiet:

```
# with this change
input.Close returned in 11.292µs with: context canceled

# with the shutdown reduced to quitting the loop
--- FAIL: TestTrackBuildFailureClosesAStalledInput (5.33s)
    the input was left waiting on a relay read that may never return
```

## Fix

`fail` shuts down through `SendEOS`, which cancels the input as well as stopping the loop. RTMP's relay request has carried the pipeline context since #279, so the cancel aborts the parked read and `io.Copy` returns.

Cancelling then creates a second problem: `input.Close` reports `context.Canceled`, and `pipelineErr` was only consulted when the input and sink both closed cleanly, so the cancellation would be reported in place of the real cause. Measured before the fix:

```
fail recorded "could not add video track" on pipelineErr, then:
  input=context.Canceled sink=nil     -> Run returns context canceled
  input=context.Canceled sink=roomErr -> Run returns room disconnected
  input=nil              sink=nil     -> Run returns could not add video track
```

`resolveRunError` runs after the existing sink rule and rescues only the first row. A recorded cause beats a cancellation, anything more specific still wins, and with nothing recorded a cancellation stands, so a kill reports exactly as it does today.

## WHIP does not have this problem, and the cancel does not affect it

Worth stating explicitly, since the failure path now shuts down through `SendEOS` for every source.

**It cannot stall the way RTMP does.** `whipAppSource` runs its blocking read on a separate goroutine behind a channel, and `copyRelayedData` waits on a `select` over that channel and a fuse. `Close` breaks the fuse, so it returns `io.EOF` without the HTTP read completing, and the parked reader is released afterwards by the deferred `resp.Body.Close()`. Measured on `main`, with the same silent-publisher setup that blocks RTMP past five seconds:

| source | `Close()` with no cancel |
|---|---|
| WHIP | **88µs**, returned `EOF` |
| RTMP | **blocked past 5s** |

That difference is not a policy choice. WHIP's relay carries per-frame timestamps, so it cannot use `io.Copy` and had to hand-write its loop, and a hand-written loop has somewhere to put a fuse.

**The cancel cannot reach it.** WHIP's relay is a plain `http.Get` with no context, so cancelling the pipeline context has no effect on its request or its body.

**Two other candidates checked and ruled out.** `PushBuffer` cannot pin the loop outside the select: `block` defaults to false and `leaky-type` to none, so the queue grows rather than blocking the pusher. Measured with the appsrc built exactly as the WHIP source builds it, in a playing pipeline with nothing draining it:

```
max-bytes=200000 block=false
pushed 4096000 bytes, slowest PushBuffer: 17.041µs
```

And the per-track `result` channel that `WHIPSource.Close` waits on is only ever written by the goroutine `Start` spawns, so a track that never started would block that receive forever. Unreachable today, because `Input.Close` has one caller after the loop, the loop only runs if `input.Start` returned nil, and `WHIPSource.Start` returns on the first track that fails. Nothing enforces that chain, so it is worth knowing about; raising it separately rather than here.

## URL pull, including SRT and UDP, is unaffected for a different reason

`URLSource.Start` takes a context and ignores it: the parameter is `_ context.Context`, and all it does is spawn a stats ticker. The media is pulled by GStreamer elements inside the pipeline, `souphttpsrc`, `srtclientsrc` or `udpsrc`, driven by their own streaming threads rather than by Go code. There is no relay, no `io.Copy` and no goroutine to release.

`URLSource.Close` breaks a fuse and returns nil without waiting on anything, so `input.Close` cannot stall for this source either.

One thing this change does alter for it. `SendEOS` drives the pipeline to `StateNull`, and the failure path did not do that before: on main only `messageWatch`'s EOS arm and `SendEOS` itself set NULL, so a track-build failure left the source elements running until the handler process exited. They are now stopped properly. If that transition is slow, and `URLSource.Close` carries a `TODO find a way to send a EOS event without hanging` suggesting this source is where it might be, `SendEOS`'s five-second watchdog quits the loop anyway and logs `pipeline frozen`.

## Tests

`TestTrackBuildFailureClosesAStalledInput` builds a real `Input` with a real RTMP source over a relay that goes quiet, triggers the failure, and asserts the close returns. `TestResolveRunErrorPrefersRecordedCause` pins the precedence, including the row that keeps a kill unchanged.

Both confirmed by breaking the code they guard:

| mutation | caught |
|---|---|
| the shutdown reduced to quitting the loop | `TestTrackBuildFailureClosesAStalledInput` |
| `errors.Is(err, context.Canceled)` changed to `DeadlineExceeded` | `TestResolveRunErrorPrefersRecordedCause` |

The new test runs a real GStreamer bin and HTTP server, so I checked it for flakiness: eight consecutive runs pass, and it is clean under `-race`. Its timing bound is five seconds against an 11µs actual.

`TestTrackBuildFailureStopsTheSessionWhileReportingStalls` from #482 still passes, so the state update still cannot delay the teardown.

## What this brings with it

- **`fail` now needs `p.pipeline`.** `SendEOS` drives the state change, so a nil pipeline panics in its goroutine. Two test fixtures move to the file's `newTestPipeline` for that reason.
- **The failure path breaks the `closed` fuse.** It comes to mean "a shutdown was requested" and "a failure happened". A later `SendEOS` from a DELETE becomes a no-op, harmless since teardown is already running. `Run`'s early return on that fuse is not reachable from `fail`, since pads only appear after `input.Start`.
- **A stalled state update can produce a misleading log line.** The NULL transition needs the streaming threads to stop, and this one is still inside the callback sending the update. If that hangs, `SendEOS`'s five-second watchdog fires, logs `pipeline frozen`, and quits the loop anyway. Bounded, but the message names the wrong thing.
- **The loop quit is no longer immediate.** It waits for the NULL transition, or five seconds. Normally milliseconds.

## Verification

From the CI config: `go build ./...` clean, `go test -timeout 20m ./pkg/...` passes across 8 packages, `golangci-lint run --timeout=5m --modules-download-mode=mod` reports 0 issues.

## Not covered

The test does not add the input bin to the pipeline, so no media flows through `decodebin3`. It covers the chain from the failure to the relay read and nothing beyond it; `Run` and the sink need a room connection.

WHIP is covered by the measurements above rather than by a test in this PR.

Separately, and pre-existing: `WebRTCSink.Close` opens with an unbounded `<-s.sdkReady.Watch()`, `messageWatch`'s bus-error path does not cancel so it can stall the same way, and an RTMP session ended by DELETE reports `ENDPOINT_ERROR` rather than INACTIVE. Filing those on their own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
